### PR TITLE
fix: log Vercel 404 root cause in DEVLOG

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -22,6 +22,22 @@
 
 ---
 
+## Bug Fixes
+
+### [BUG] Vercel 404 on favicon and index — 2026-03-21 [FIXED]
+
+**Symptoms:** `/favicon.ico` returning 404, then `/` returning 404 on Vercel production deployment.
+
+**Root cause:** Both 404s shared the same cause — the `main` branch contained only the initial commit (README.md, issues.md). No `package.json`, no `src/`. Vercel's production deployment watched `main`, found no framework, served nothing.
+
+**Fixes applied:**
+1. `public/favicon.ico` — copied favicon here so it is served as a static file directly, bypassing Next.js App Router metadata handling. The App Router serves `src/app/favicon.ico` via the metadata API; browsers also request `/favicon.ico` as a raw static path. Both are now covered.
+2. Merged M1 branch to `main` — the actual fix for all production 404s. No app code = nothing to serve.
+
+**Gotcha for future deploys:** Vercel production always builds from `main`. Never expect a feature branch to fix production — merge it.
+
+---
+
 ## Entries
 
 ### [M1 #1] Scaffold — 2026-03-21 [DONE]


### PR DESCRIPTION
## Summary

Documents the Vercel 404 bug fix that affected the initial production deployment.

- Adds a **Bug Fixes** section to DEVLOG.md above the issue entries
- Records root cause, both fixes applied, and the gotcha for future deploys

## Root Cause (for reference)

`main` had only the initial commit — no `package.json`, no `src/`. Vercel's production deployment watched `main`, found no framework, 404'd on everything. Both the favicon and index 404s were the same underlying cause.

## Fixes already merged to main

1. `public/favicon.ico` — static fallback for direct browser requests to `/favicon.ico`
2. M1 branch merged to `main` — the actual fix

## Test plan

- [x] No code changes — DEVLOG only
- [x] `npm run build` clean on main
- [x] Vercel production rebuilt after M1 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)