### PR TITLE
fix: force Next.js framework preset on Vercel

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -28,13 +28,15 @@
 
 **Symptoms:** `/favicon.ico` returning 404, then `/` returning 404 on Vercel production deployment.
 
-**Root cause:** Both 404s shared the same cause — the `main` branch contained only the initial commit (README.md, issues.md). No `package.json`, no `src/`. Vercel's production deployment watched `main`, found no framework, served nothing.
+**Root cause (favicon):** `main` contained only the initial commit (README.md, issues.md) — no app code. Fixed by merging M1.
+
+**Root cause (index — persistent after M1 merge):** Vercel was first connected to the repo before any code existed. At that point it saved the Framework Preset as "Other" (static site). This preset is sticky — merging M1 did not trigger re-detection. Evidence: Vercel's deployment file listing showed only the six default `public/*.svg` files, confirming it was serving only static files and never running `next build`. The Next.js route table seen in CI (GitHub Actions) was never produced by Vercel itself.
 
 **Fixes applied:**
-1. `public/favicon.ico` — copied favicon here so it is served as a static file directly, bypassing Next.js App Router metadata handling. The App Router serves `src/app/favicon.ico` via the metadata API; browsers also request `/favicon.ico` as a raw static path. Both are now covered.
-2. Merged M1 branch to `main` — the actual fix for all production 404s. No app code = nothing to serve.
+1. `public/favicon.ico` — copied favicon to serve as static file, covering the raw `/favicon.ico` browser request in addition to the App Router metadata API path.
+2. `vercel.json` with `{ "framework": "nextjs" }` — Vercel reads this before dashboard settings, overriding the stale "Other" preset and forcing the full Next.js build pipeline.
 
-**Gotcha for future deploys:** Vercel production always builds from `main`. Never expect a feature branch to fix production — merge it.
+**Gotcha for future projects:** Connect Vercel only after pushing a `package.json`. If connected to an empty repo, the Framework Preset may be saved as "Other" and won't auto-correct — add `vercel.json` to force it.
 
 ---
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with `{ "framework": "nextjs" }` to override Vercel's stale Framework Preset
- Updates DEVLOG.md with full root cause analysis for the persistent 404

## Root cause

Vercel was first connected when `main` had only a README. It saved the Framework Preset as "Other" (static site). Merging M1 did not trigger re-detection — Vercel was serving only `public/` static files and never running `next build`. Evidence: Vercel's deployment file listing showed only the six default SVGs, not any Next.js server output.

## Test plan

- [ ] Merge to `main`
- [ ] Verify Vercel production deploy log shows `next build` running and the route table with `/ (Static)`
- [ ] Production URL returns 200 on `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)