### PR TITLE
feat: M2 clone pipeline — composer + SSE route

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -9,8 +9,8 @@
 | #3 | Scraper utility | M1 | DONE |
 | #4 | Page discovery | M1 | DONE |
 | #5 | Extractors | M1 | DONE |
-| #6 | Composer utility | M2 | PENDING |
-| #7 | /api/clone SSE route | M2 | PENDING |
+| #6 | Composer utility | M2 | DONE |
+| #7 | /api/clone SSE route | M2 | DONE |
 | #8 | UrlInputPanel | M3 | PENDING |
 | #9 | ProgressFeed | M3 | PENDING |
 | #10 | PageTabBar + PagePreview | M3 | PENDING |
@@ -41,6 +41,42 @@
 ---
 
 ## Entries
+
+### [M2 #6] Composer utility — 2026-03-21 [DONE]
+
+**What was built:**
+- `src/lib/composer.ts` — `composePage(design, content, allPages, apiKey)` calls Claude (`claude-sonnet-4-6`, max_tokens 8192) with a structured JSON user message containing the design system, page content, navigation structure, and active slug
+- CSS truncated to 8000 chars before passing to Claude
+- Validates response starts with `<!DOCTYPE html>` (case-insensitive); throws descriptive error otherwise
+- Anthropic client instantiated per-call (not module-level) to support BYOK key injection
+- 6 unit tests via `vi.mock('@anthropic-ai/sdk')` — all passing
+
+**Decisions:**
+- `claude-sonnet-4-6` — capable enough for polished HTML generation, cost-effective vs Opus
+- Client instantiated inside function, not at module level — avoids stale key if apiKey changes between calls
+- `block?.type === 'text'` optional chain — safe against empty content array (code review catch)
+
+**Gotchas:**
+- `vi.mock` factory for Anthropic must return a plain constructor function (not `vi.fn().mockImplementation`) — otherwise `new Anthropic()` throws "not a constructor"
+
+---
+
+### [M2 #7] /api/clone SSE route — 2026-03-21 [DONE]
+
+**What was built:**
+- `src/app/api/clone/route.ts` — GET handler streaming SSE events for the full clone pipeline
+- Auth: `x-api-key` header (BYOK) takes precedence over `ANTHROPIC_API_KEY` env var; 401 if neither
+- Pipeline: scrape design → scrape content → discover pages → extract design system → per-page: extract content + compose + emit `page_complete`
+- All errors caught → `error` SSE event → stream closes
+- `maxPages` read from `DEMO_PAGE_LIMIT` env var (default 6); full session tracking deferred to M4
+- `eslint.config.mjs` updated to ignore `coverage/**` (lint was flagging generated coverage files)
+- 9 route unit tests with all lib functions mocked — all passing
+
+**Decisions:**
+- Auth simplified for M2: no cookie/session tracking — full demo session (run counts, session IDs) is M4 work when the UI is built
+- `extractPageContent` called without `await` (it is synchronous; spec incorrectly marks it async)
+
+---
 
 ### [M1 #1] Scaffold — 2026-03-21 [DONE]
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ const eslintConfig = [
       ".next/**",
       "out/**",
       "build/**",
+      "coverage/**",
       "next-env.d.ts",
     ],
   },

--- a/src/app/api/clone/__tests__/route.test.ts
+++ b/src/app/api/clone/__tests__/route.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/scraper', () => ({
+  scrapeSite: vi.fn(),
+}))
+vi.mock('@/lib/discover', () => ({
+  discoverPages: vi.fn(),
+}))
+vi.mock('@/lib/extractor', () => ({
+  extractDesignSystem: vi.fn(),
+  extractPageContent: vi.fn(),
+}))
+vi.mock('@/lib/composer', () => ({
+  composePage: vi.fn(),
+}))
+
+import { GET } from '../route'
+import { scrapeSite } from '@/lib/scraper'
+import { discoverPages } from '@/lib/discover'
+import { extractDesignSystem, extractPageContent } from '@/lib/extractor'
+import { composePage } from '@/lib/composer'
+import type { ScrapedSite, DiscoveredPage, DesignSystem, PageContent } from '@/lib/types'
+
+const mockScrapeSite = vi.mocked(scrapeSite)
+const mockDiscoverPages = vi.mocked(discoverPages)
+const mockExtractDesignSystem = vi.mocked(extractDesignSystem)
+const mockExtractPageContent = vi.mocked(extractPageContent)
+const mockComposePage = vi.mocked(composePage)
+
+const fakeSite: ScrapedSite = { url: 'https://example.com', html: '<html/>', css: '', title: 'Test' }
+const fakePages: DiscoveredPage[] = [
+  { url: 'https://example.com/', title: 'Home', slug: 'index', navLabel: 'Home' },
+]
+const fakeDesign: DesignSystem = {
+  colorPalette: [], fontStack: [], spacing: [], borderRadius: [],
+  componentPatterns: { nav: '', hero: '', footer: '', card: '', button: '' },
+  rawCss: '',
+}
+const fakeContent: PageContent = {
+  url: 'https://example.com/', title: 'Home', slug: 'index',
+  headings: [], paragraphs: [], listItems: [], ctaTexts: [], imageAlts: [], metaDescription: '',
+}
+const fakeHtml = '<!DOCTYPE html><html><body>Hello</body></html>'
+
+function makeRequest(params: Record<string, string>, headers: Record<string, string> = {}) {
+  const url = new URL('http://localhost:3000/api/clone')
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return new Request(url.toString(), { headers })
+}
+
+async function collectStream(response: Response): Promise<string> {
+  const text = await response.text()
+  return text
+}
+
+function parseEvents(raw: string) {
+  return raw
+    .split('\n\n')
+    .filter(Boolean)
+    .map((line) => {
+      const data = line.replace(/^data: /, '')
+      try { return JSON.parse(data) } catch { return null }
+    })
+    .filter(Boolean)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.ANTHROPIC_API_KEY
+})
+
+describe('GET /api/clone', () => {
+  it('returns 400 when designUrl is missing', async () => {
+    const res = await GET(makeRequest({ contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when contentUrl is missing', async () => {
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 401 when no API key is available', async () => {
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('uses x-api-key header when provided', async () => {
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await GET(makeRequest(
+      { designUrl: 'https://stripe.com', contentUrl: 'https://example.com' },
+      { 'x-api-key': 'byok-key' }
+    ))
+    expect(res.status).toBe(200)
+    await collectStream(res)
+    expect(mockComposePage).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), 'byok-key'
+    )
+  })
+
+  it('uses env ANTHROPIC_API_KEY as fallback', async () => {
+    process.env.ANTHROPIC_API_KEY = 'env-key'
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(200)
+    await collectStream(res)
+    expect(mockComposePage).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), 'env-key'
+    )
+  })
+
+  it('x-api-key header takes precedence over env var', async () => {
+    process.env.ANTHROPIC_API_KEY = 'env-key'
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await GET(makeRequest(
+      { designUrl: 'https://stripe.com', contentUrl: 'https://example.com' },
+      { 'x-api-key': 'byok-key' }
+    ))
+    await collectStream(res)
+    expect(mockComposePage).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), 'byok-key'
+    )
+  })
+
+  it('streams status, page_complete, and done events on success', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+
+    const raw = await collectStream(res)
+    const events = parseEvents(raw)
+    const types = events.map((e: { type: string }) => e.type)
+
+    expect(types).toContain('status')
+    expect(types).toContain('page_complete')
+    expect(types[types.length - 1]).toBe('done')
+  })
+
+  it('streams an error event when scrapeSite throws', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockScrapeSite.mockRejectedValue(new Error('Network failure'))
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    const raw = await collectStream(res)
+    const events = parseEvents(raw)
+    const errorEvent = events.find((e: { type: string }) => e.type === 'error')
+
+    expect(errorEvent).toBeDefined()
+    expect(errorEvent.error).toMatch(/Network failure/)
+  })
+})

--- a/src/app/api/clone/route.ts
+++ b/src/app/api/clone/route.ts
@@ -1,4 +1,76 @@
-// Clone SSE route — implemented in M2
-export async function GET() {
-  return new Response('Not implemented', { status: 501 })
+import { scrapeSite } from '@/lib/scraper'
+import { discoverPages } from '@/lib/discover'
+import { extractDesignSystem, extractPageContent } from '@/lib/extractor'
+import { composePage } from '@/lib/composer'
+import type { CloneEvent, ClonedPage } from '@/lib/types'
+
+const encoder = new TextEncoder()
+
+function send(controller: ReadableStreamDefaultController, event: CloneEvent) {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url)
+  const designUrl = searchParams.get('designUrl')
+  const contentUrl = searchParams.get('contentUrl')
+
+  if (!designUrl || !contentUrl) {
+    return new Response('Missing parameters', { status: 400 })
+  }
+
+  const apiKey =
+    request.headers.get('x-api-key') ?? process.env.ANTHROPIC_API_KEY ?? ''
+
+  if (!apiKey) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const maxPages = parseInt(process.env.DEMO_PAGE_LIMIT ?? '6')
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        send(controller, { type: 'status', message: 'Scraping design site...' })
+        const designSite = await scrapeSite(designUrl)
+
+        send(controller, { type: 'status', message: 'Scraping content site...' })
+        const contentSite = await scrapeSite(contentUrl)
+
+        send(controller, { type: 'status', message: 'Discovering pages...' })
+        const pages = discoverPages(contentSite, maxPages)
+
+        send(controller, { type: 'status', message: `Found ${pages.length} page(s)` })
+        const designSystem = extractDesignSystem(designSite)
+
+        for (const page of pages) {
+          send(controller, { type: 'status', message: `Generating ${page.navLabel}...` })
+          const content = extractPageContent(contentSite, page)
+          const html = await composePage(designSystem, content, pages, apiKey)
+          const clonedPage: ClonedPage = {
+            slug: page.slug,
+            title: page.title,
+            navLabel: page.navLabel,
+            html,
+            generatedAt: new Date().toISOString(),
+          }
+          send(controller, { type: 'page_complete', page: clonedPage })
+        }
+
+        send(controller, { type: 'done' })
+      } catch (err) {
+        send(controller, { type: 'error', error: String(err) })
+      } finally {
+        controller.close()
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  })
 }

--- a/src/lib/__tests__/composer.test.ts
+++ b/src/lib/__tests__/composer.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { DesignSystem, DiscoveredPage, PageContent } from '../types'
+
+// Mock the Anthropic SDK before importing composer
+const mockCreate = vi.fn()
+vi.mock('@anthropic-ai/sdk', () => {
+  function MockAnthropic() {
+    return { messages: { create: mockCreate } }
+  }
+  return { default: MockAnthropic }
+})
+
+import { composePage } from '../composer'
+
+const makeDesign = (rawCss = 'body { color: red; }'): DesignSystem => ({
+  colorPalette: ['#ff0000'],
+  fontStack: ['Arial'],
+  spacing: ['8px'],
+  borderRadius: ['4px'],
+  componentPatterns: { nav: '<nav/>', hero: '', footer: '', card: '', button: '' },
+  rawCss,
+})
+
+const makeContent = (): PageContent => ({
+  url: 'https://example.com/about',
+  title: 'About',
+  slug: 'about',
+  headings: ['About Us'],
+  paragraphs: ['We build great things.'],
+  listItems: [],
+  ctaTexts: ['Learn more'],
+  imageAlts: [],
+  metaDescription: 'About page',
+})
+
+const makePages = (): DiscoveredPage[] => [
+  { url: 'https://example.com/', title: 'Home', slug: 'index', navLabel: 'Home' },
+  { url: 'https://example.com/about', title: 'About', slug: 'about', navLabel: 'About' },
+]
+
+const validHtml = '<!DOCTYPE html><html><head></head><body>Hello</body></html>'
+
+function mockResponse(text: string) {
+  mockCreate.mockResolvedValueOnce({
+    content: [{ type: 'text', text }],
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('composePage', () => {
+  it('returns a string starting with <!DOCTYPE html>', async () => {
+    mockResponse(validHtml)
+    const result = await composePage(makeDesign(), makeContent(), makePages(), 'test-key')
+    expect(result).toMatch(/^<!DOCTYPE html>/i)
+  })
+
+  it('throws when response does not start with <!DOCTYPE html>', async () => {
+    mockResponse('Here is your HTML: <!DOCTYPE html><html></html>')
+    await expect(
+      composePage(makeDesign(), makeContent(), makePages(), 'test-key')
+    ).rejects.toThrow('Claude did not return valid HTML')
+  })
+
+  it('throws when response is empty', async () => {
+    mockCreate.mockResolvedValueOnce({ content: [{ type: 'tool_use', id: 'x', name: 'y', input: {} }] })
+    await expect(
+      composePage(makeDesign(), makeContent(), makePages(), 'test-key')
+    ).rejects.toThrow('Claude did not return valid HTML')
+  })
+
+  it('truncates rawCss to 8000 characters', async () => {
+    mockResponse(validHtml)
+    const longCss = 'a'.repeat(12000)
+    await composePage(makeDesign(longCss), makeContent(), makePages(), 'test-key')
+
+    const callArg = mockCreate.mock.calls[0][0]
+    const userContent = JSON.parse(callArg.messages[0].content)
+    expect(userContent.designSystem.rawCss.length).toBeLessThanOrEqual(8000)
+  })
+
+  it('includes all page slugs in the navigation array', async () => {
+    mockResponse(validHtml)
+    const pages = makePages()
+    await composePage(makeDesign(), makeContent(), pages, 'test-key')
+
+    const callArg = mockCreate.mock.calls[0][0]
+    const userContent = JSON.parse(callArg.messages[0].content)
+    const navSlugs = userContent.navigation.map((n: { slug: string }) => n.slug)
+    for (const page of pages) {
+      expect(navSlugs).toContain(page.slug)
+    }
+  })
+
+  it('sets currentSlug to content.slug', async () => {
+    mockResponse(validHtml)
+    const content = makeContent()
+    await composePage(makeDesign(), content, makePages(), 'test-key')
+
+    const callArg = mockCreate.mock.calls[0][0]
+    const userContent = JSON.parse(callArg.messages[0].content)
+    expect(userContent.currentSlug).toBe(content.slug)
+  })
+
+  it('accepts <!doctype html> (lowercase) as valid', async () => {
+    mockResponse('<!doctype html><html></html>')
+    const result = await composePage(makeDesign(), makeContent(), makePages(), 'test-key')
+    expect(result).toMatch(/^<!doctype html>/i)
+  })
+})

--- a/src/lib/composer.ts
+++ b/src/lib/composer.ts
@@ -1,4 +1,65 @@
-// Composer utility — implemented in M2
-export async function composePage(): Promise<string> {
-  throw new Error('Not implemented')
+import Anthropic from '@anthropic-ai/sdk'
+import type { DesignSystem, DiscoveredPage, PageContent } from './types'
+
+const CSS_CHAR_LIMIT = 8000
+
+const SYSTEM_PROMPT = `You are an expert web developer. You will be given a design system extracted
+from one website and content extracted from another. Your job is to produce
+a complete, self-contained HTML page that:
+
+1. Uses the visual design (colors, fonts, spacing, component patterns) from the design system
+2. Fills that design with the provided content
+3. Includes a working navigation linking to all provided pages
+4. Is entirely self-contained — all CSS must be inline or in a <style> tag, no external dependencies
+5. Looks polished and professional
+6. Uses semantic HTML5 elements
+
+Return ONLY the complete HTML document starting with <!DOCTYPE html>.
+No explanation, no markdown, no code fences.`
+
+export async function composePage(
+  design: DesignSystem,
+  content: PageContent,
+  allPages: DiscoveredPage[],
+  apiKey: string
+): Promise<string> {
+  const client = new Anthropic({ apiKey })
+
+  const userMessage = JSON.stringify({
+    designSystem: {
+      colorPalette: design.colorPalette,
+      fontStack: design.fontStack,
+      spacing: design.spacing,
+      borderRadius: design.borderRadius,
+      componentPatterns: design.componentPatterns,
+      rawCss: design.rawCss.slice(0, CSS_CHAR_LIMIT),
+    },
+    pageContent: {
+      title: content.title,
+      headings: content.headings,
+      paragraphs: content.paragraphs,
+      listItems: content.listItems,
+      ctaTexts: content.ctaTexts,
+      imageAlts: content.imageAlts,
+      metaDescription: content.metaDescription,
+    },
+    navigation: allPages.map((p) => ({ slug: p.slug, label: p.navLabel })),
+    currentSlug: content.slug,
+  })
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 8192,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: userMessage }],
+  })
+
+  const block = response.content[0]
+  const text = block?.type === 'text' ? block.text : ''
+
+  if (!/^<!doctype html>/i.test(text.trimStart())) {
+    throw new Error('Claude did not return valid HTML')
+  }
+
+  return text
 }


### PR DESCRIPTION
## Summary

- `src/lib/composer.ts` — calls `claude-sonnet-4-6` with a structured JSON prompt (design system + page content + nav); truncates CSS to 8000 chars; validates `<!DOCTYPE html>` response
- `src/app/api/clone/route.ts` — GET handler streaming the full pipeline as SSE events; auth via `x-api-key` header (BYOK) or `ANTHROPIC_API_KEY` env var
- 15 new tests (6 composer, 9 route); 61 total passing
- ESLint ignores `coverage/` directory

## Test plan

- [ ] `npm test` — 61 passing
- [ ] `npm run typecheck` — zero errors
- [ ] `npm run build` — clean, `/api/clone` appears as dynamic route
- [ ] CI green
- [ ] Manual: `curl "http://localhost:3000/api/clone?designUrl=...&contentUrl=..." -H "x-api-key: $KEY"` streams `status`, `page_complete`, `done` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)