### PR TITLE
feat: M4 — download ZIP, BYOK, demo session, polish, README

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -15,10 +15,10 @@
 | #9 | ProgressFeed | M3 | DONE |
 | #10 | PageTabBar + PagePreview | M3 | DONE |
 | #11 | Main page + SSE client | M3 | DONE |
-| #12 | /api/download + ZIP | M4 | PENDING |
-| #13 | ApiKeyInput + DemoBanner | M4 | PENDING |
-| #14 | Polish pass | M4 | PENDING |
-| #15 | README + deploy | M4 | PENDING |
+| #12 | /api/download + ZIP | M4 | DONE |
+| #13 | ApiKeyInput + DemoBanner | M4 | DONE |
+| #14 | Polish pass | M4 | DONE |
+| #15 | README + deploy | M4 | DONE |
 
 ---
 
@@ -41,6 +41,31 @@
 ---
 
 ## Entries
+
+### [M4 #12–15] Polish + Ship — 2026-03-21 [DONE]
+
+**What was built:**
+- `src/app/api/download/route.ts` — POST handler that collects archiver ZIP output into a `Buffer` via a `Writable` sink, returns `application/zip` response; compression level 6 (zlib default, good tradeoff for HTML)
+- `src/lib/demo.ts` — `getDemoSession`, `incrementDemoRun`, `getByokSession`, `saveByokSession`, `clearByokSession`; all guarded with `isServer()` check; uses existing `DemoSession`/`ByokSession` types from `types.ts` (which include `startedAt`/`addedAt` timestamps)
+- `src/components/ApiKeyInput.tsx` — fixed-position modal; password input; validates `key.startsWith('sk-ant-')`; calls `onSave(key)` + `onClose()` on valid submit; backdrop-click-to-close via `stopPropagation` on card
+- `src/components/DemoBanner.tsx` — sticky banner with 3 states (BYOK active / runs remaining / limit reached); consolidated into single render path with shared outer div
+- `src/app/page.tsx` — replaced `EventSource` + `sourceRef` with `fetch` + `ReadableStream` reader + `AbortController`; full BYOK/demo session wiring; Download button; responsive layout (`flex-col md:flex-row`)
+- `README.md` — complete rewrite with pipeline diagram, env vars table, demo/BYOK docs, tech stack, potential extensions
+- 27 new tests (demo.ts + download route + ApiKeyInput + DemoBanner); 121 total passing
+
+**Decisions:**
+- `fetch` + `ReadableStream` replaces `EventSource` — EventSource cannot send custom headers; one code path covers both demo (no header) and BYOK (`x-api-key` header)
+- Demo enforcement client-side only via `sessionStorage` — no server-side run counting needed for a portfolio project
+- `NEXT_PUBLIC_DEMO_RUN_LIMIT` env var — Next.js requires `NEXT_PUBLIC_` prefix for client-readable vars; added to `.env.example`
+- Compression level 6 (not 9) — HTML compresses well at any level; level 9 adds CPU blocking with negligible size benefit
+- `useMemo` for `activePage` — avoids `pages.find()` linear scan on unrelated renders (e.g. `isDownloading` toggle)
+- `AbortError` check in `catch` — intentional abort should not flip `isRunning`; handled in catch only, not `finally`
+
+**Gotchas:**
+- archiver `finish` listener must be registered before `finalize()` is called — the event fires immediately after `finalize()` resolves; registering after misses it (race condition fixed in download route)
+- `DemoSession` in `types.ts` includes `startedAt: string` field not in the original spec — agent used the canonical type rather than redefining a simpler one
+
+---
 
 ### [M3 #8–11] UI + Streaming — 2026-03-21 [DONE]
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,94 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# kaminify
 
-## Getting Started
+Paste two URLs — a design source and a content source — and kaminify's AI pipeline scrapes both sites, extracts the visual design system from the first, pulls the structured content from the second, and uses Claude to generate a cloned multi-page site that applies the design of one to the content of the other. Pages appear progressively as they're generated; preview them live in-browser and download the full site as a ZIP.
 
-First, run the development server:
+**[kaminify.vercel.app](https://kaminify.vercel.app)**
+
+[Watch the walkthrough](LOOM_URL_HERE)
+
+---
+
+## Pipeline
+
+```text
+User submits designUrl + contentUrl
+  └── GET /api/clone?designUrl=X&contentUrl=Y   (SSE stream)
+        ├── scrapeSite(designUrl)                 scrape HTML + CSS
+        ├── scrapeSite(contentUrl)                scrape HTML + CSS
+        ├── discoverPages(contentSite)            parse nav → DiscoveredPage[]
+        ├── extractDesignSystem(designSite)       colors, fonts, spacing, components
+        └── for each discovered page:
+              extractPageContent(page)            headings, paragraphs, CTAs, meta
+              composePage(design, content, apiKey) → Claude → self-contained HTML
+              emit  { type: "page_complete", page }  (SSE)
+        └── emit  { type: "done" }                (SSE)
+```
+
+---
+
+## Local Setup
+
+```bash
+git clone https://github.com/your-username/kaminify.git
+cd kaminify
+npm install
+```
+
+Copy the example env file and fill in your Anthropic key:
+
+```bash
+cp .env.example .env.local
+```
+
+```env
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Start the dev server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+---
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Environment Variables
 
-## Learn More
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `ANTHROPIC_API_KEY` | Yes | — | Server-side Anthropic key used for demo runs |
+| `DEMO_RUN_LIMIT` | No | `3` | Max clone runs allowed per session in demo mode |
+| `DEMO_PAGE_LIMIT` | No | `3` | Max pages cloned per run in demo mode |
+| `NEXT_PUBLIC_DEMO_RUN_LIMIT` | No | `3` | Client-visible run limit used for UI enforcement |
 
-To learn more about Next.js, take a look at the following resources:
+---
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Demo Mode / BYOK
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+**Demo mode** — the hosted app gives every visitor 3 free runs using the server-side Anthropic key. No sign-up required.
 
-## Deploy on Vercel
+**Bring Your Own Key (BYOK)** — click "Use your own API key" in the banner to enter your Anthropic API key. It is stored in `sessionStorage` only, passed directly to the API as a request header, and never persisted on the server. BYOK mode removes all run and page limits.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+---
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Tech Stack
+
+| Layer | Choice |
+| --- | --- |
+| Framework | Next.js 15 (App Router) |
+| Language | TypeScript |
+| Styling | Tailwind CSS v4 |
+| AI | Anthropic Claude (claude-sonnet-4-6) |
+| HTML parsing | cheerio |
+| ZIP generation | archiver |
+| Deployment | Vercel |
+
+---
+
+## Potential Extensions
+
+- **Persistent history** — save clone jobs to a database so users can revisit or share previously generated sites.
+- **Custom prompts** — expose a prompt editor so users can steer Claude's interpretation of the design system (e.g., "make it darker", "use a two-column layout").
+- **Team sharing** — generate a shareable preview link per clone job, with expiry and password protection.

--- a/src/app/api/download/__tests__/route.test.ts
+++ b/src/app/api/download/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import { POST } from '../route'
+import type { ClonedPage } from '@/lib/types'
+
+function makeClonedPage(slug: string, html: string): ClonedPage {
+  return {
+    slug,
+    title: `${slug} page`,
+    navLabel: slug,
+    html,
+    generatedAt: new Date().toISOString(),
+  }
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost:3000/api/download', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/download', () => {
+  it('returns 200 with Content-Type application/zip for valid pages', async () => {
+    const pages: ClonedPage[] = [
+      makeClonedPage('index', '<!DOCTYPE html><html><body>Home</body></html>'),
+      makeClonedPage('about', '<!DOCTYPE html><html><body>About</body></html>'),
+    ]
+
+    const res = await POST(makeRequest({ pages }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/zip')
+
+    const buffer = await res.arrayBuffer()
+    expect(buffer.byteLength).toBeGreaterThan(0)
+  })
+
+  it('returns 200 with Content-Type application/zip for empty pages array', async () => {
+    const res = await POST(makeRequest({ pages: [] }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/zip')
+
+    const buffer = await res.arrayBuffer()
+    expect(buffer.byteLength).toBeGreaterThan(0)
+  })
+
+  it('returns 400 when pages key is missing from body', async () => {
+    const res = await POST(makeRequest({ foo: 'bar' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when body is malformed JSON', async () => {
+    const req = new Request('http://localhost:3000/api/download', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-valid-json{{{',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/app/api/download/route.ts
+++ b/src/app/api/download/route.ts
@@ -1,4 +1,50 @@
-// Download ZIP route — implemented in M4
-export async function POST() {
-  return new Response('Not implemented', { status: 501 })
+import archiver from 'archiver'
+import { Writable } from 'stream'
+import type { ClonedPage } from '@/lib/types'
+
+export async function POST(request: Request): Promise<Response> {
+  let body: { pages?: ClonedPage[] }
+  try {
+    body = await request.json()
+  } catch {
+    return new Response('Bad Request', { status: 400 })
+  }
+
+  const pages = body?.pages
+  if (!Array.isArray(pages)) {
+    return new Response('Bad Request', { status: 400 })
+  }
+
+  const chunks: Uint8Array[] = []
+  const sink = new Writable({
+    write(chunk: Buffer, _encoding: BufferEncoding, cb: () => void) {
+      chunks.push(chunk)
+      cb()
+    },
+  })
+
+  const archive = archiver('zip', { zlib: { level: 6 } })
+  archive.pipe(sink)
+
+  for (const page of pages) {
+    const filename = page.slug === 'index' ? 'index.html' : `${page.slug}.html`
+    archive.append(page.html, { name: filename })
+  }
+
+  // Register finish/error listeners before calling finalize() to avoid missing the event
+  const sinkDone = new Promise<void>((resolve, reject) => {
+    sink.on('finish', resolve)
+    sink.on('error', reject)
+  })
+
+  await archive.finalize()
+  await sinkDone
+
+  const buffer = Buffer.concat(chunks)
+  return new Response(buffer, {
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': 'attachment; filename="cloned-site.zip"',
+    },
+  })
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,16 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { CloneEvent, ClonedPage } from '@/lib/types'
+import { getDemoSession, incrementDemoRun, getByokSession, saveByokSession, clearByokSession } from '@/lib/demo'
 import UrlInputPanel from '@/components/UrlInputPanel'
 import ProgressFeed from '@/components/ProgressFeed'
 import PageTabBar from '@/components/PageTabBar'
 import PagePreview from '@/components/PagePreview'
 import DemoBanner from '@/components/DemoBanner'
+import ApiKeyInput from '@/components/ApiKeyInput'
+
+const DEMO_RUN_LIMIT = parseInt(process.env.NEXT_PUBLIC_DEMO_RUN_LIMIT ?? '3')
 
 export default function Home() {
   const [isRunning, setIsRunning] = useState(false)
@@ -14,14 +18,26 @@ export default function Home() {
   const [pages, setPages] = useState<ClonedPage[]>([])
   const [activeSlug, setActiveSlug] = useState<string | null>(null)
   const [hasStarted, setHasStarted] = useState(false)
-  const sourceRef = useRef<EventSource | null>(null)
+  const [apiKey, setApiKey] = useState<string | null>(null)
+  const [runsUsed, setRunsUsed] = useState(0)
+  const [showApiKeyInput, setShowApiKeyInput] = useState(false)
+  const [isDownloading, setIsDownloading] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
-    return () => { sourceRef.current?.close() }
+    const byok = getByokSession()
+    if (byok) setApiKey(byok.apiKey)
+    setRunsUsed(getDemoSession().runsUsed)
   }, [])
 
-  function startClone(designUrl: string, contentUrl: string) {
-    sourceRef.current?.close()
+  useEffect(() => {
+    return () => { abortRef.current?.abort() }
+  }, [])
+
+  async function startClone(designUrl: string, contentUrl: string) {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
 
     setIsRunning(true)
     setHasStarted(true)
@@ -29,38 +45,107 @@ export default function Home() {
     setPages([])
     setActiveSlug(null)
 
-    const params = new URLSearchParams({ designUrl, contentUrl })
-    const source = new EventSource(`/api/clone?${params}`)
-    sourceRef.current = source
-
-    source.onmessage = (e: MessageEvent) => {
-      const event: CloneEvent = JSON.parse(e.data as string)
-      setEvents((prev) => [...prev, event])
-
-      if (event.type === 'page_complete') {
-        setPages((prev) => [...prev, event.page])
-        setActiveSlug((prev) => prev ?? event.page.slug)
-      }
-      if (event.type === 'done' || event.type === 'error') {
-        setIsRunning(false)
-        source.close()
-      }
+    if (!apiKey) {
+      const updated = incrementDemoRun()
+      setRunsUsed(updated.runsUsed)
     }
 
-    source.onerror = () => {
-      setIsRunning(false)
-      source.close()
+    const headers: Record<string, string> = {}
+    if (apiKey) headers['x-api-key'] = apiKey
+
+    const params = new URLSearchParams({ designUrl, contentUrl })
+
+    try {
+      const res = await fetch(`/api/clone?${params}`, {
+        headers,
+        signal: controller.signal,
+      })
+
+      if (!res.ok || !res.body) {
+        setIsRunning(false)
+        return
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const parts = buffer.split('\n\n')
+        buffer = parts.pop() ?? ''
+
+        for (const part of parts) {
+          const line = part.trim()
+          if (!line.startsWith('data: ')) continue
+          try {
+            const event: CloneEvent = JSON.parse(line.slice(6))
+            setEvents((prev) => [...prev, event])
+
+            if (event.type === 'page_complete') {
+              setPages((prev) => [...prev, event.page])
+              setActiveSlug((prev) => prev ?? event.page.slug)
+            }
+            if (event.type === 'done' || event.type === 'error') {
+              setIsRunning(false)
+            }
+          } catch {
+            // malformed event — skip
+          }
+        }
+      }
+    } catch (err: unknown) {
+      // AbortError is intentional — don't surface as an error state
+      if (!(err instanceof Error && err.name === 'AbortError')) {
+        setIsRunning(false)
+      }
     }
   }
 
-  const activePage = pages.find((p) => p.slug === activeSlug) ?? null
+  async function handleDownload() {
+    setIsDownloading(true)
+    try {
+      const res = await fetch('/api/download', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pages }),
+      })
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'cloned-site.zip'
+      a.click()
+      URL.revokeObjectURL(url)
+    } finally {
+      setIsDownloading(false)
+    }
+  }
+
+  function handleSaveApiKey(key: string) {
+    saveByokSession(key)
+    setApiKey(key)
+  }
+
+  function handleClearApiKey() {
+    clearByokSession()
+    setApiKey(null)
+  }
+
+  const activePage = useMemo(
+    () => pages.find((p) => p.slug === activeSlug) ?? null,
+    [pages, activeSlug],
+  )
+  const demoLimitReached = !apiKey && runsUsed >= DEMO_RUN_LIMIT
 
   return (
     <main
       className="min-h-screen flex flex-col"
       style={{ backgroundColor: 'var(--color-bg-primary)' }}
     >
-      {/* Header */}
       <header
         className="px-6 py-4 border-b flex items-center gap-4"
         style={{ borderColor: 'var(--color-border)' }}
@@ -71,25 +156,51 @@ export default function Home() {
         <span className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
           Paste two URLs. Get a cloned site.
         </span>
+        {apiKey && (
+          <button
+            onClick={handleClearApiKey}
+            className="ml-auto text-xs"
+            style={{ color: 'var(--color-text-muted)' }}
+          >
+            Remove API key
+          </button>
+        )}
       </header>
 
-      {/* Demo banner — null in M3, implemented in M4 */}
-      <DemoBanner />
+      <DemoBanner
+        runsUsed={runsUsed}
+        runLimit={DEMO_RUN_LIMIT}
+        hasApiKey={!!apiKey}
+        onOpenApiKeyInput={() => setShowApiKeyInput(true)}
+      />
 
-      {/* URL input */}
       <section className="px-6 py-8 w-full max-w-4xl mx-auto">
-        <UrlInputPanel onClone={startClone} isRunning={isRunning} />
+        <UrlInputPanel
+          onClone={startClone}
+          isRunning={isRunning}
+          disabled={demoLimitReached}
+        />
+        {!isRunning && pages.length > 0 && (
+          <div className="mt-4 flex justify-end">
+            <button
+              onClick={handleDownload}
+              disabled={isDownloading}
+              className="px-4 py-2 rounded-md text-sm font-medium text-white disabled:opacity-50"
+              style={{ backgroundColor: 'var(--color-accent)' }}
+            >
+              {isDownloading ? 'Preparing ZIP…' : 'Download ZIP'}
+            </button>
+          </div>
+        )}
       </section>
 
-      {/* Pipeline output — only visible after first run */}
       {hasStarted && (
         <div
-          className="flex flex-1 min-h-0 border-t"
+          className="flex flex-1 min-h-0 border-t flex-col md:flex-row"
           style={{ borderColor: 'var(--color-border)' }}
         >
-          {/* Left: progress feed */}
           <aside
-            className="w-[280px] shrink-0 border-r overflow-hidden flex flex-col"
+            className="md:w-[280px] shrink-0 md:border-r border-b md:border-b-0 overflow-hidden flex flex-col"
             style={{ borderColor: 'var(--color-border)', backgroundColor: 'var(--color-bg-elevated)' }}
           >
             <div
@@ -101,14 +212,18 @@ export default function Home() {
             <ProgressFeed events={events} isRunning={isRunning} />
           </aside>
 
-          {/* Right: tabs + preview */}
           <div className="flex flex-col flex-1 min-h-0">
             <PageTabBar pages={pages} activeSlug={activeSlug} onSelect={setActiveSlug} />
-            <div className="flex flex-1 min-h-0">
-              <PagePreview page={activePage} isLoading={isRunning && pages.length === 0} />
-            </div>
+            <PagePreview page={activePage} isLoading={isRunning && pages.length === 0} />
           </div>
         </div>
+      )}
+
+      {showApiKeyInput && (
+        <ApiKeyInput
+          onSave={handleSaveApiKey}
+          onClose={() => setShowApiKeyInput(false)}
+        />
       )}
     </main>
   )

--- a/src/components/ApiKeyInput.tsx
+++ b/src/components/ApiKeyInput.tsx
@@ -1,3 +1,87 @@
-export default function ApiKeyInput() {
-  return null
+'use client'
+
+import { useState } from 'react'
+
+const KEY_PREFIX = 'sk-ant-'
+
+interface ApiKeyInputProps {
+  onSave: (apiKey: string) => void
+  onClose: () => void
+}
+
+export default function ApiKeyInput({ onSave, onClose }: ApiKeyInputProps) {
+  const [key, setKey] = useState('')
+  const [error, setError] = useState('')
+
+  function handleSave() {
+    const trimmed = key.trim()
+    if (!trimmed.startsWith(KEY_PREFIX)) {
+      setError(`Key must start with ${KEY_PREFIX}`)
+      return
+    }
+    onSave(trimmed)
+    onClose()
+  }
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center z-50"
+      style={{ backgroundColor: 'rgba(0,0,0,0.7)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-lg border p-6 flex flex-col gap-4"
+        style={{ backgroundColor: 'var(--color-bg-elevated)', borderColor: 'var(--color-border)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-base font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+          Enter your Anthropic API key
+        </h2>
+        <p className="text-sm -mt-2" style={{ color: 'var(--color-text-muted)' }}>
+          Your key is stored in sessionStorage and never sent to our servers.
+        </p>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium" htmlFor="api-key-input" style={{ color: 'var(--color-text-secondary)' }}>
+            API Key
+          </label>
+          <input
+            id="api-key-input"
+            type="password"
+            value={key}
+            onChange={(e) => { setKey(e.target.value); setError('') }}
+            placeholder={`${KEY_PREFIX}...`}
+            className="rounded-md border px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2"
+            style={{
+              backgroundColor: 'var(--color-bg-input)',
+              borderColor: error ? 'var(--color-error)' : 'var(--color-border)',
+              color: 'var(--color-text-primary)',
+            }}
+          />
+          {error && (
+            <span className="text-xs" style={{ color: 'var(--color-error)' }}>
+              {error}
+            </span>
+          )}
+        </div>
+
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-md text-sm border"
+            style={{ borderColor: 'var(--color-border)', color: 'var(--color-text-secondary)' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 rounded-md text-sm font-medium text-white"
+            style={{ backgroundColor: 'var(--color-accent)' }}
+          >
+            Save key
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/components/DemoBanner.tsx
+++ b/src/components/DemoBanner.tsx
@@ -1,3 +1,41 @@
-export default function DemoBanner() {
-  return null
+'use client'
+
+interface DemoBannerProps {
+  runsUsed: number
+  runLimit: number
+  hasApiKey: boolean
+  onOpenApiKeyInput: () => void
+}
+
+export default function DemoBanner({ runsUsed, runLimit, hasApiKey, onOpenApiKeyInput }: DemoBannerProps) {
+  const bannerClass = 'sticky top-0 z-10 px-6 py-2 text-sm border-b flex items-center gap-1'
+  const bannerStyle = { backgroundColor: 'var(--color-bg-elevated)', borderColor: 'var(--color-border)' }
+
+  if (hasApiKey) {
+    return (
+      <div className={bannerClass} style={bannerStyle}>
+        <span style={{ color: 'var(--color-success)' }}>✓ Using your API key — unlimited runs</span>
+      </div>
+    )
+  }
+
+  const limitReached = runsUsed >= runLimit
+
+  return (
+    <div className={bannerClass} style={{ ...bannerStyle, color: 'var(--color-text-secondary)' }}>
+      {limitReached ? (
+        <span style={{ color: 'var(--color-warning)' }}>Demo limit reached</span>
+      ) : (
+        <span>{runsUsed} of {runLimit} demo runs used</span>
+      )}
+      <span> · </span>
+      <button
+        onClick={onOpenApiKeyInput}
+        className="underline cursor-pointer"
+        style={{ color: 'var(--color-accent)' }}
+      >
+        {limitReached ? 'Add your API key to continue' : 'Use your own API key →'}
+      </button>
+    </div>
+  )
 }

--- a/src/components/__tests__/ApiKeyInput.test.tsx
+++ b/src/components/__tests__/ApiKeyInput.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ApiKeyInput from '../ApiKeyInput'
+
+function setup(props: Partial<{ onSave: (k: string) => void; onClose: () => void }> = {}) {
+  const onSave = props.onSave ?? vi.fn()
+  const onClose = props.onClose ?? vi.fn()
+  render(<ApiKeyInput onSave={onSave} onClose={onClose} />)
+  return { onSave, onClose }
+}
+
+describe('ApiKeyInput', () => {
+  it('renders the modal with title "Enter your Anthropic API key"', () => {
+    setup()
+    expect(screen.getByText('Enter your Anthropic API key')).toBeInTheDocument()
+  })
+
+  it('shows error when saving key that does not start with sk-ant-', async () => {
+    setup()
+    const input = screen.getByLabelText('API Key')
+    await userEvent.type(input, 'invalid-key')
+    await userEvent.click(screen.getByRole('button', { name: /save key/i }))
+    expect(screen.getByText('Key must start with sk-ant-')).toBeInTheDocument()
+  })
+
+  it('shows no error initially', () => {
+    setup()
+    expect(screen.queryByText(/key must start with/i)).not.toBeInTheDocument()
+  })
+
+  it('calls onSave and onClose with trimmed key on valid save', async () => {
+    const { onSave, onClose } = setup()
+    const input = screen.getByLabelText('API Key')
+    await userEvent.type(input, '  sk-ant-mykey123  ')
+    await userEvent.click(screen.getByRole('button', { name: /save key/i }))
+    expect(onSave).toHaveBeenCalledWith('sk-ant-mykey123')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const { onClose } = setup()
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when backdrop is clicked', () => {
+    const { onClose } = setup()
+    // The backdrop is the outermost fixed div; clicking it directly triggers onClose
+    const backdrop = screen.getByText('Enter your Anthropic API key').closest('[class*="fixed"]') as HTMLElement
+    fireEvent.click(backdrop!)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('error clears when input changes after an error', async () => {
+    setup()
+    const input = screen.getByLabelText('API Key')
+    await userEvent.type(input, 'bad-key')
+    await userEvent.click(screen.getByRole('button', { name: /save key/i }))
+    expect(screen.getByText('Key must start with sk-ant-')).toBeInTheDocument()
+    await userEvent.type(input, 'x')
+    expect(screen.queryByText('Key must start with sk-ant-')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/DemoBanner.test.tsx
+++ b/src/components/__tests__/DemoBanner.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DemoBanner from '../DemoBanner'
+
+describe('DemoBanner', () => {
+  it('hasApiKey=true renders "Using your API key — unlimited runs"', () => {
+    render(<DemoBanner runsUsed={0} runLimit={3} hasApiKey={true} onOpenApiKeyInput={() => {}} />)
+    expect(screen.getByText(/Using your API key — unlimited runs/)).toBeInTheDocument()
+  })
+
+  it('hasApiKey=true does NOT render run counts', () => {
+    render(<DemoBanner runsUsed={2} runLimit={3} hasApiKey={true} onOpenApiKeyInput={() => {}} />)
+    expect(screen.queryByText(/of 3 demo runs used/)).not.toBeInTheDocument()
+  })
+
+  it('hasApiKey=false, runsUsed=1, runLimit=3 renders "1 of 3 demo runs used"', () => {
+    render(<DemoBanner runsUsed={1} runLimit={3} hasApiKey={false} onOpenApiKeyInput={() => {}} />)
+    expect(screen.getByText('1 of 3 demo runs used')).toBeInTheDocument()
+  })
+
+  it('hasApiKey=false, runsUsed=0, runLimit=3 renders "Use your own API key →" button', () => {
+    render(<DemoBanner runsUsed={0} runLimit={3} hasApiKey={false} onOpenApiKeyInput={() => {}} />)
+    expect(screen.getByRole('button', { name: /Use your own API key →/ })).toBeInTheDocument()
+  })
+
+  it('hasApiKey=false, runsUsed=3, runLimit=3 renders "Demo limit reached"', () => {
+    render(<DemoBanner runsUsed={3} runLimit={3} hasApiKey={false} onOpenApiKeyInput={() => {}} />)
+    expect(screen.getByText('Demo limit reached')).toBeInTheDocument()
+  })
+
+  it('hasApiKey=false, runsUsed=3, runLimit=3 renders "Add your API key to continue" button', () => {
+    render(<DemoBanner runsUsed={3} runLimit={3} hasApiKey={false} onOpenApiKeyInput={() => {}} />)
+    expect(screen.getByRole('button', { name: /Add your API key to continue/ })).toBeInTheDocument()
+  })
+
+  it('clicking "Use your own API key →" calls onOpenApiKeyInput', async () => {
+    const handler = vi.fn()
+    render(<DemoBanner runsUsed={1} runLimit={3} hasApiKey={false} onOpenApiKeyInput={handler} />)
+    await userEvent.click(screen.getByRole('button', { name: /Use your own API key →/ }))
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('clicking "Add your API key to continue" calls onOpenApiKeyInput', async () => {
+    const handler = vi.fn()
+    render(<DemoBanner runsUsed={3} runLimit={3} hasApiKey={false} onOpenApiKeyInput={handler} />)
+    await userEvent.click(screen.getByRole('button', { name: /Add your API key to continue/ }))
+    expect(handler).toHaveBeenCalledOnce()
+  })
+})

--- a/src/lib/__tests__/demo.test.ts
+++ b/src/lib/__tests__/demo.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getDemoSession,
+  incrementDemoRun,
+  getByokSession,
+  saveByokSession,
+  clearByokSession,
+} from '../demo'
+
+beforeEach(() => {
+  sessionStorage.clear()
+})
+
+describe('getDemoSession', () => {
+  it('returns { runsUsed: 0 } when storage is empty', () => {
+    const session = getDemoSession()
+    expect(session.runsUsed).toBe(0)
+  })
+})
+
+describe('incrementDemoRun', () => {
+  it('increments runsUsed from 0 to 1', () => {
+    const session = incrementDemoRun()
+    expect(session.runsUsed).toBe(1)
+  })
+
+  it('persists — getDemoSession after incrementDemoRun returns { runsUsed: 1 }', () => {
+    incrementDemoRun()
+    const session = getDemoSession()
+    expect(session.runsUsed).toBe(1)
+  })
+
+  it('increments correctly when called twice', () => {
+    incrementDemoRun()
+    const session = incrementDemoRun()
+    expect(session.runsUsed).toBe(2)
+  })
+})
+
+describe('getByokSession', () => {
+  it('returns null when storage is empty', () => {
+    expect(getByokSession()).toBeNull()
+  })
+})
+
+describe('saveByokSession', () => {
+  it('returns { apiKey: "sk-ant-test" }', () => {
+    const session = saveByokSession('sk-ant-test')
+    expect(session.apiKey).toBe('sk-ant-test')
+  })
+
+  it('getByokSession returns the saved session after saveByokSession', () => {
+    saveByokSession('sk-ant-test')
+    const session = getByokSession()
+    expect(session).not.toBeNull()
+    expect(session!.apiKey).toBe('sk-ant-test')
+  })
+})
+
+describe('clearByokSession', () => {
+  it('removes the session — getByokSession returns null after clear', () => {
+    saveByokSession('sk-ant-test')
+    clearByokSession()
+    expect(getByokSession()).toBeNull()
+  })
+})

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -1,2 +1,58 @@
-// Demo session logic — implemented in M4
-export {}
+import type { DemoSession, ByokSession } from './types'
+
+const DEMO_KEY = 'kaminify_demo_session'
+const BYOK_KEY = 'kaminify_byok_session'
+
+function isServer(): boolean {
+  return typeof window === 'undefined'
+}
+
+function defaultDemoSession(): DemoSession {
+  return { runsUsed: 0, startedAt: new Date().toISOString() }
+}
+
+export function getDemoSession(): DemoSession {
+  if (isServer()) return defaultDemoSession()
+  try {
+    const raw = sessionStorage.getItem(DEMO_KEY)
+    if (!raw) return defaultDemoSession()
+    return JSON.parse(raw) as DemoSession
+  } catch {
+    return defaultDemoSession()
+  }
+}
+
+export function incrementDemoRun(): DemoSession {
+  if (isServer()) return defaultDemoSession()
+  const session = getDemoSession()
+  const updated: DemoSession = {
+    runsUsed: session.runsUsed + 1,
+    startedAt: session.startedAt,
+  }
+  sessionStorage.setItem(DEMO_KEY, JSON.stringify(updated))
+  return updated
+}
+
+export function getByokSession(): ByokSession | null {
+  if (isServer()) return null
+  try {
+    const raw = sessionStorage.getItem(BYOK_KEY)
+    if (!raw) return null
+    return JSON.parse(raw) as ByokSession
+  } catch {
+    return null
+  }
+}
+
+export function saveByokSession(apiKey: string): ByokSession {
+  const session: ByokSession = { apiKey, addedAt: new Date().toISOString() }
+  if (!isServer()) {
+    sessionStorage.setItem(BYOK_KEY, JSON.stringify(session))
+  }
+  return session
+}
+
+export function clearByokSession(): void {
+  if (isServer()) return
+  sessionStorage.removeItem(BYOK_KEY)
+}


### PR DESCRIPTION
## Summary

- **Issue #12** — `/api/download` POST route: archiver ZIP collected into Buffer via Writable sink, returns `application/zip`; compression level 6
- **Issue #13** — `src/lib/demo.ts` session management (getDemoSession, incrementDemoRun, getByokSession, saveByokSession, clearByokSession, all SSR-safe); `ApiKeyInput` modal with `sk-ant-` validation; `DemoBanner` 3-state sticky banner; `page.tsx` major rewrite replacing EventSource with `fetch` + `ReadableStream` for BYOK header support
- **Issue #14** — Polish: `useMemo` for `activePage`, responsive two-column layout (`flex-col md:flex-row`), removed unnecessary JSX comments and wrapper divs
- **Issue #15** — README complete rewrite: pipeline diagram, env vars table, demo/BYOK docs, tech stack, potential extensions

## Test plan

- [ ] 121 tests passing (`npm test`)
- [ ] Typecheck clean (`npx tsc --noEmit`)
- [ ] Manual: demo mode — 3 clones exhaust limit, Clone button disables
- [ ] Manual: BYOK — enter `sk-ant-...` key, Clone re-enables, key sent as `x-api-key` header
- [ ] Manual: Download ZIP — button appears after pages load, ZIP contains correctly named `.html` files
- [ ] Manual: responsive — two-column collapses to single column on narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)