### PR TITLE
feat: surface timeout and error messaging to the user

### DIFF
--- a/src/app/api/clone/route.ts
+++ b/src/app/api/clone/route.ts
@@ -69,7 +69,7 @@ export async function GET(request: Request): Promise<Response> {
 
         send(controller, { type: 'done' })
       } catch (err) {
-        send(controller, { type: 'error', error: String(err) })
+        send(controller, { type: 'error', error: err instanceof Error ? err.message : String(err) })
       } finally {
         controller.close()
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,6 +69,8 @@ export default function Home() {
       const reader = res.body.getReader()
       const decoder = new TextDecoder()
       let buffer = ''
+      let receivedDone = false
+      let completedPages = 0
 
       while (true) {
         const { done, value } = await reader.read()
@@ -86,18 +88,30 @@ export default function Home() {
             setEvents((prev) => [...prev, event])
 
             if (event.type === 'page_complete') {
+              completedPages += 1
               setPages((prev) => [...prev, event.page])
               setActiveSlug((prev) => prev ?? event.page.slug)
             }
-            if (event.type === 'done' || event.type === 'error') {
-              setIsRunning(false)
+            if (event.type === 'done') {
+              receivedDone = true
             }
           } catch {
             // malformed event — skip
           }
         }
       }
-      // Stream ended without a 'done' event (e.g. Vercel killed the function)
+
+      if (!receivedDone && !abortRef.current?.signal.aborted) {
+        setEvents(prev => [
+          ...prev,
+          {
+            type: 'warning' as const,
+            message: completedPages > 0
+              ? `Generation stopped — server timeout reached. ${completedPages} page(s) completed and ready to download.`
+              : 'Generation stopped before any pages completed. The server timed out — try fewer pages, or add your own API key for longer runs.',
+          },
+        ])
+      }
       setIsRunning(false)
     } catch (err: unknown) {
       // AbortError is intentional — don't surface as an error state

--- a/src/components/ProgressFeed.tsx
+++ b/src/components/ProgressFeed.tsx
@@ -102,6 +102,15 @@ export default function ProgressFeed({ events, isRunning }: ProgressFeedProps) {
           )
         }
 
+        if (event.type === 'warning') {
+          return (
+            <div key={i} className="flex items-start gap-2 py-1" style={{ color: 'var(--color-warning)' }}>
+              <span className="w-4 shrink-0 mt-0.5 text-center">!</span>
+              <span>{event.message}</span>
+            </div>
+          )
+        }
+
         if (event.type === 'done') {
           return (
             <div key={i} className="flex items-center gap-2 py-1 font-bold" style={{ color: 'var(--color-success)' }}>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,6 +65,7 @@ export interface CloneResult {
 export type CloneEvent =
   | { type: 'status'; message: string }
   | { type: 'progress'; message: string }   // live update while Claude is generating (replaces current step display)
+  | { type: 'warning'; message: string }
   | { type: 'page_complete'; page: ClonedPage }
   | { type: 'error'; error: string }
   | { type: 'done' }


### PR DESCRIPTION
## Summary

Fixes the silent failure mode — Vercel's 60s serverless timeout was cutting the SSE stream with no user feedback.

- **Stream termination detection** — after the SSE reader loop, if `done` was never received and the user didn't click Stop, inject an amber warning into ProgressFeed: either _"X page(s) completed and ready to download"_ or guidance to try fewer pages / use BYOK
- **`warning` CloneEvent type** — amber (`--color-warning`) with `!` icon, distinct from hard errors (red `✕`)
- **Cleaner error messages** — `err.message` instead of `String(err)` in route.ts strips the class-name prefix from API errors
- **Single `setIsRunning(false)`** — removed redundant early calls inside the event loop; one unconditional call after the loop covers all paths

## Test plan
- [x] `npm run test` — 125 passing
- [x] `npm run build` — clean
- [ ] Manual: run a multi-page clone that times out → amber warning appears with page count
- [ ] Manual: run with bad URL → clean error message, no `Error: Error:` prefix
- [ ] Manual: click Stop → no warning shown (intentional abort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)