### PR TITLE
feat: mobile preview toggle (closes #36)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -24,6 +24,20 @@
 
 ## Entries
 
+### [feat/issue-36-mobile-preview-toggle] Mobile preview toggle — 2026-03-21 [IN PROGRESS]
+
+**What was built:**
+- `src/app/page.tsx` — added `mobilePreview: boolean` state (default `false`); wired to `PageTabBar` and `PagePreview`; state persists across page tab changes
+- `src/components/PageTabBar.tsx` — added Desktop/Mobile toggle icon-buttons on the right side of the tab bar; monitor + smartphone SVG icons; active mode gets accent color + dim background; `aria-label` and `aria-pressed` for accessibility; tabs inner div gets `flex-1` + `overflow-x-auto` so tabs scroll independently from toggle
+- `src/components/PagePreview.tsx` — added `mobilePreview?: boolean` prop; when true, wraps iframe in centering container with `--color-bg-base` background and renders iframe at fixed 375px width with subtle `box-shadow` ring; desktop path unchanged
+
+**Design decisions:**
+- State persists across page tab changes — if you're checking mobile rendering, you want all pages in mobile mode
+- No device chrome frame — clean dark background with a subtle outline shadow is sufficient for the portfolio aesthetic
+- Toggle buttons guard no-op clicks (clicking active mode does nothing)
+
+---
+
 ### [feat/issue-38-prompt-iteration] Model selector + pipeline hardening — 2026-03-21 [DONE — PR #44 → staging → main]
 
 **What was built:**

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ export default function Home() {
   const [runsUsed, setRunsUsed] = useState(0)
   const [showApiKeyInput, setShowApiKeyInput] = useState(false)
   const [isDownloading, setIsDownloading] = useState(false)
+  const [mobilePreview, setMobilePreview] = useState(false)
   const abortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
@@ -295,8 +296,14 @@ export default function Home() {
           </aside>
 
           <div className="flex flex-col flex-1 min-h-0">
-            <PageTabBar pages={pages} activeSlug={activeSlug} onSelect={setActiveSlug} />
-            <PagePreview page={activePage} isLoading={isRunning && pages.length === 0} />
+            <PageTabBar
+              pages={pages}
+              activeSlug={activeSlug}
+              onSelect={setActiveSlug}
+              mobilePreview={mobilePreview}
+              onToggleMobilePreview={() => setMobilePreview((v) => !v)}
+            />
+            <PagePreview page={activePage} isLoading={isRunning && pages.length === 0} mobilePreview={mobilePreview} />
           </div>
         </div>
       )}

--- a/src/components/PagePreview.tsx
+++ b/src/components/PagePreview.tsx
@@ -8,9 +8,10 @@ const GeneratingAnimation = dynamic(() => import('./GeneratingAnimation'), { ssr
 interface PagePreviewProps {
   page: ClonedPage | null
   isLoading?: boolean
+  mobilePreview?: boolean
 }
 
-export default function PagePreview({ page, isLoading }: PagePreviewProps) {
+export default function PagePreview({ page, isLoading, mobilePreview }: PagePreviewProps) {
   const blobUrlRef = useRef<string | null>(null)
   const [iframeSrc, setIframeSrc] = useState<string | null>(null)
 
@@ -48,6 +49,28 @@ export default function PagePreview({ page, isLoading }: PagePreviewProps) {
 
   if (!iframeSrc) {
     return null
+  }
+
+  if (mobilePreview) {
+    return (
+      <div
+        className="flex flex-1 justify-center overflow-auto"
+        style={{ backgroundColor: 'var(--color-bg-base)', minHeight: 0 }}
+      >
+        <iframe
+          src={iframeSrc}
+          title={page.title}
+          sandbox="allow-scripts allow-same-origin"
+          style={{
+            width: 375,
+            flexShrink: 0,
+            border: 'none',
+            boxShadow: '0 0 0 1px rgba(255,255,255,0.08), 0 8px 32px rgba(0,0,0,0.4)',
+            alignSelf: 'stretch',
+          }}
+        />
+      </div>
+    )
   }
 
   return (

--- a/src/components/PageTabBar.tsx
+++ b/src/components/PageTabBar.tsx
@@ -4,34 +4,71 @@ interface PageTabBarProps {
   pages: ClonedPage[]
   activeSlug: string | null
   onSelect: (slug: string) => void
+  mobilePreview: boolean
+  onToggleMobilePreview: () => void
 }
 
-export default function PageTabBar({ pages, activeSlug, onSelect }: PageTabBarProps) {
+export default function PageTabBar({ pages, activeSlug, onSelect, mobilePreview, onToggleMobilePreview }: PageTabBarProps) {
   if (pages.length === 0) return null
 
   return (
     <div
-      className="flex flex-row overflow-x-auto shrink-0 border-b"
+      className="flex flex-row items-center shrink-0 border-b"
       style={{ borderColor: 'var(--color-border)', backgroundColor: 'var(--color-bg-elevated)' }}
     >
-      {pages.map((page) => {
-        const isActive = page.slug === activeSlug
-        return (
-          <button
-            key={page.slug}
-            onClick={() => onSelect(page.slug)}
-            className={[
-              'px-4 py-2 text-sm font-medium whitespace-nowrap border-b-2 transition-colors',
-              'focus:outline-none',
-              isActive
-                ? 'border-[var(--color-accent)] text-[var(--color-text-primary)]'
-                : 'border-transparent text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border)]',
-            ].join(' ')}
-          >
-            {page.navLabel}
-          </button>
-        )
-      })}
+      <div className="flex flex-row overflow-x-auto flex-1">
+        {pages.map((page) => {
+          const isActive = page.slug === activeSlug
+          return (
+            <button
+              key={page.slug}
+              onClick={() => onSelect(page.slug)}
+              className={[
+                'px-4 py-2 text-sm font-medium whitespace-nowrap border-b-2 transition-colors',
+                'focus:outline-none',
+                isActive
+                  ? 'border-[var(--color-accent)] text-[var(--color-text-primary)]'
+                  : 'border-transparent text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border)]',
+              ].join(' ')}
+            >
+              {page.navLabel}
+            </button>
+          )
+        })}
+      </div>
+      <div className="ml-auto flex items-center gap-1 pr-3 shrink-0">
+        <button
+          onClick={() => { if (mobilePreview) onToggleMobilePreview() }}
+          aria-label="Desktop preview"
+          aria-pressed={!mobilePreview}
+          className="px-2 py-1.5 rounded text-xs flex items-center gap-1 transition-colors focus:outline-none"
+          style={{
+            color: !mobilePreview ? 'var(--color-accent)' : 'var(--color-text-muted)',
+            backgroundColor: !mobilePreview ? 'rgba(249,115,22,0.1)' : 'transparent',
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <line x1="8" y1="21" x2="16" y2="21"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+        </button>
+        <button
+          onClick={() => { if (!mobilePreview) onToggleMobilePreview() }}
+          aria-label="Mobile preview"
+          aria-pressed={mobilePreview}
+          className="px-2 py-1.5 rounded text-xs flex items-center gap-1 transition-colors focus:outline-none"
+          style={{
+            color: mobilePreview ? 'var(--color-accent)' : 'var(--color-text-muted)',
+            backgroundColor: mobilePreview ? 'rgba(249,115,22,0.1)' : 'transparent',
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="5" y="2" width="14" height="20" rx="2"/>
+            <line x1="12" y1="18" x2="12.01" y2="18"/>
+          </svg>
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds Desktop/Mobile toggle icon-buttons to the right side of the preview tab bar
- Mobile mode constrains the iframe to 375px, centered over a dark background with a subtle shadow ring
- Desktop mode is unchanged (full-width iframe)
- Toggle state persists across page tab changes — switching pages stays in whichever mode is active
- Accessible: `aria-label` and `aria-pressed` on each button

## Test plan
- [x] Generate a multi-page site, confirm toggle buttons appear in the tab bar
- [x] Click Mobile icon — iframe narrows to 375px, centered, dark background visible on sides
- [x] Click Desktop icon — iframe returns to full width
- [x] Switch page tabs while in Mobile mode — mode persists
- [x] Verify build and lint pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)