### PR TITLE
fix: remove onBlur validation to fix example pill double-click bug (c…

### DIFF
--- a/src/components/UrlInputPanel.tsx
+++ b/src/components/UrlInputPanel.tsx
@@ -77,8 +77,7 @@ export default function UrlInputPanel({ onClone, isRunning, disabled, model, onM
             type="url"
             placeholder="https://stripe.com"
             value={designUrl}
-            onChange={(e) => setDesignUrl(e.target.value)}
-            onBlur={() => setDesignError(validateUrl(designUrl))}
+            onChange={(e) => { setDesignUrl(e.target.value); setDesignError('') }}
             className="px-3 py-2 rounded-md text-sm border focus:outline-none focus:border-[var(--color-accent)]"
             style={{
               backgroundColor: 'var(--color-bg-input)',
@@ -107,8 +106,7 @@ export default function UrlInputPanel({ onClone, isRunning, disabled, model, onM
             type="url"
             placeholder="https://your-site.com"
             value={contentUrl}
-            onChange={(e) => setContentUrl(e.target.value)}
-            onBlur={() => setContentError(validateUrl(contentUrl))}
+            onChange={(e) => { setContentUrl(e.target.value); setContentError('') }}
             className="px-3 py-2 rounded-md text-sm border focus:outline-none focus:border-[var(--color-accent)]"
             style={{
               backgroundColor: 'var(--color-bg-input)',

--- a/src/components/__tests__/UrlInputPanel.test.tsx
+++ b/src/components/__tests__/UrlInputPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import UrlInputPanel from '../UrlInputPanel'
 
@@ -41,21 +41,22 @@ describe('UrlInputPanel', () => {
     expect(screen.getByLabelText('running')).toBeInTheDocument()
   })
 
-  it('shows inline error on blur with invalid URL', () => {
+  it('shows validation error on submit with invalid URL', async () => {
     setup()
-    const input = screen.getByLabelText('Design source URL')
-    fireEvent.change(input, { target: { value: 'not-a-url' } })
-    fireEvent.blur(input)
+    await userEvent.type(screen.getByLabelText('Design source URL'), 'not-a-url')
+    await userEvent.type(screen.getByLabelText('Content source URL'), 'https://example.com')
+    await userEvent.click(screen.getByRole('button', { name: /clone/i }))
     expect(screen.getByText(/must start with http/i)).toBeInTheDocument()
   })
 
-  it('shows no error for valid URL on blur', () => {
+  it('clears error immediately when user starts correcting', async () => {
     setup()
-    const input = screen.getByLabelText('Design source URL')
-    fireEvent.change(input, { target: { value: 'https://stripe.com' } })
-    fireEvent.blur(input)
+    await userEvent.type(screen.getByLabelText('Design source URL'), 'not-a-url')
+    await userEvent.type(screen.getByLabelText('Content source URL'), 'https://example.com')
+    await userEvent.click(screen.getByRole('button', { name: /clone/i }))
+    expect(screen.getByText(/must start with http/i)).toBeInTheDocument()
+    await userEvent.type(screen.getByLabelText('Design source URL'), 's')
     expect(screen.queryByText(/must start with http/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/invalid url/i)).not.toBeInTheDocument()
   })
 
   it('Clone button enabled when both inputs are valid URLs', async () => {
@@ -82,11 +83,11 @@ describe('UrlInputPanel', () => {
     expect(screen.getByLabelText('Content source URL')).toHaveValue('https://github.com')
   })
 
-  it('pill click clears existing errors', async () => {
+  it('pill click clears submit errors', async () => {
     setup()
-    const input = screen.getByLabelText('Design source URL')
-    fireEvent.change(input, { target: { value: 'bad-url' } })
-    fireEvent.blur(input)
+    await userEvent.type(screen.getByLabelText('Design source URL'), 'not-a-url')
+    await userEvent.type(screen.getByLabelText('Content source URL'), 'https://example.com')
+    await userEvent.click(screen.getByRole('button', { name: /clone/i }))
     expect(screen.getByText(/must start with http/i)).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: 'Stripe + GitHub' }))
     expect(screen.queryByText(/must start with http/i)).not.toBeInTheDocument()


### PR DESCRIPTION
…loses #45)

Validation errors now only show on submit attempt, and clear immediately on change. Eliminates the blur/click race where the pill stealing focus would set an error that persisted on first click.