### PR TITLE
fix: robust error display and browser scrape timeout (hotfix)

### DIFF
--- a/src/app/api/clone/route.ts
+++ b/src/app/api/clone/route.ts
@@ -85,7 +85,13 @@ export async function GET(request: Request): Promise<Response> {
 
         send(controller, { type: 'done' })
       } catch (err) {
-        send(controller, { type: 'error', error: err instanceof Error ? err.message : String(err) })
+        let message: string
+        if (err instanceof Error) {
+          message = err.message
+        } else {
+          try { message = JSON.stringify(err) ?? 'Unknown error' } catch { message = 'Unknown error' }
+        }
+        send(controller, { type: 'error', error: message })
       } finally {
         controller.close()
       }

--- a/src/lib/browserScraper.ts
+++ b/src/lib/browserScraper.ts
@@ -16,7 +16,7 @@ export async function scrapeWithBrowser(url: string): Promise<ScrapedSite> {
 
   try {
     await page.setUserAgent(USER_AGENT)
-    await page.goto(url, { waitUntil: 'networkidle2', timeout: 15_000 })
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15_000 })
 
     const html = await page.content()
     const $ = cheerio.load(html)


### PR DESCRIPTION
## Summary
- `route.ts`: replaces `String(err)` with `JSON.stringify` + try/catch fallback — non-Error throws from any part of the pipeline (including puppeteer) will never show as `[object Object]` again
- `browserScraper.ts`: `networkidle2` → `domcontentloaded` to avoid timeouts on pages with persistent background network traffic

## Test plan
- [ ] Build and 142 tests passing
- [ ] Any thrown non-Error object in the pipeline surfaces a readable message
- [ ] Browser scrape completes without timing out on networkidle2

🤖 Generated with [Claude Code](https://claude.com/claude-code)