### PR TITLE
fix: step-level error context in browser scraper

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -24,6 +24,19 @@
 
 ## Entries
 
+### [fix/browser-scraper-diagnostics] Fix Browserless v2 WS path — 2026-03-22 [DONE]
+
+**Root cause identified from Railway logs:**
+`No matching WebSocket route handler for "http://0.0.0.0:8000/"` — Browserless v2 (`ghcr.io/browserless/chromium`) removed the root `/` WebSocket handler. Each browser now requires its own path: `/chromium` for Chromium, `/chrome` for Chrome. Our `BROWSERLESS_WS_URL` had no path segment, so every connection attempt was rejected at the routing level, producing a plain `{}` throw from puppeteer.
+
+**What was fixed:**
+- `src/lib/browserScraper.ts` — parse `BROWSERLESS_WS_URL` with `new URL()`; inject `/chromium` as pathname when path is empty or `/`; cleanup `finally` block changed from try/catch-rethrow (which shadows original errors) to `.catch()` with `console.error` (logs cleanup failures without masking the primary error)
+- `src/lib/__tests__/browserScraper.test.ts` — 2 new tests: verifies `/chromium` path injection when URL has no path; verifies no double-append when path already set; tightened existing goto error assertion to match the full wrapped message
+
+**No env var changes required** — fix is in code, existing `BROWSERLESS_WS_URL` format (no path) continues to work.
+
+---
+
 ### [feat/issue-33-browser-scraper] Browser scraper fallback — 2026-03-22 [IN PROGRESS]
 
 **What was built:**

--- a/src/lib/__tests__/browserScraper.test.ts
+++ b/src/lib/__tests__/browserScraper.test.ts
@@ -130,6 +130,42 @@ describe('scrapeWithBrowser', () => {
     expect(result.html).toContain('<p>Content</p>')
   })
 
+  it('injects /chromium path when BROWSERLESS_WS_URL has no path', async () => {
+    process.env.BROWSERLESS_WS_URL = 'wss://test.example.com'
+    const connectMock = puppeteer.connect as ReturnType<typeof vi.fn>
+    connectMock.mockResolvedValueOnce({
+      newPage: vi.fn().mockResolvedValue({
+        setUserAgent: vi.fn().mockResolvedValue(undefined),
+        goto: vi.fn().mockResolvedValue(undefined),
+        content: vi.fn().mockResolvedValue('<html></html>'),
+        close: vi.fn().mockResolvedValue(undefined),
+      }),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('')))
+    await scrapeWithBrowser('https://example.com')
+    const calledWith = connectMock.mock.calls[0][0] as { browserWSEndpoint: string }
+    expect(new URL(calledWith.browserWSEndpoint).pathname).toBe('/chromium')
+  })
+
+  it('does not double-append /chromium if path is already set', async () => {
+    process.env.BROWSERLESS_WS_URL = 'wss://test.example.com/chromium'
+    const connectMock = puppeteer.connect as ReturnType<typeof vi.fn>
+    connectMock.mockResolvedValueOnce({
+      newPage: vi.fn().mockResolvedValue({
+        setUserAgent: vi.fn().mockResolvedValue(undefined),
+        goto: vi.fn().mockResolvedValue(undefined),
+        content: vi.fn().mockResolvedValue('<html></html>'),
+        close: vi.fn().mockResolvedValue(undefined),
+      }),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('')))
+    await scrapeWithBrowser('https://example.com')
+    const calledWith = connectMock.mock.calls[0][0] as { browserWSEndpoint: string }
+    expect(new URL(calledWith.browserWSEndpoint).pathname).toBe('/chromium')
+  })
+
   it('disconnects browser even when page.goto throws', async () => {
     const mockClose = vi.fn().mockResolvedValue(undefined)
     const mockDisconnect = vi.fn().mockResolvedValue(undefined)
@@ -144,7 +180,9 @@ describe('scrapeWithBrowser', () => {
       disconnect: mockDisconnect,
     })
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('')))
-    await expect(scrapeWithBrowser('https://example.com')).rejects.toThrow('Navigation timeout')
+    await expect(scrapeWithBrowser('https://example.com')).rejects.toThrow(
+      'Browser: failed to navigate to https://example.com — Navigation timeout'
+    )
     expect(mockClose).toHaveBeenCalled()
     expect(mockDisconnect).toHaveBeenCalled()
   })

--- a/src/lib/browserScraper.ts
+++ b/src/lib/browserScraper.ts
@@ -11,7 +11,11 @@ export async function scrapeWithBrowser(url: string): Promise<ScrapedSite> {
     throw new Error('BROWSERLESS_WS_URL is not configured — browser rendering unavailable')
   }
 
-  const browser = await puppeteer.connect({ browserWSEndpoint: wsUrl })
+  const endpoint = new URL(wsUrl)
+  if (!endpoint.pathname || endpoint.pathname === '/') {
+    endpoint.pathname = '/chromium'
+  }
+  const browser = await puppeteer.connect({ browserWSEndpoint: endpoint.toString() })
 
   let page: Awaited<ReturnType<typeof browser.newPage>>
   try {
@@ -73,7 +77,11 @@ export async function scrapeWithBrowser(url: string): Promise<ScrapedSite> {
 
     return { url, html: $.html(), css, title, jsRendered: true }
   } finally {
-    await page.close()
-    await browser.disconnect()
+    await page.close().catch((err) =>
+      console.error('Browser: failed to close page —', err instanceof Error ? err.message : JSON.stringify(err))
+    )
+    await browser.disconnect().catch((err) =>
+      console.error('Browser: failed to disconnect —', err instanceof Error ? err.message : JSON.stringify(err))
+    )
   }
 }


### PR DESCRIPTION
## Summary
Wraps `newPage()` and `page.goto()` in specific try/catch blocks that rethrow with descriptive messages. Converts `{}` errors into readable pipeline messages identifying exactly which step failed.

Also fixes a resource leak: `browser.disconnect()` is now called if `newPage()` throws.

## What this tells us once deployed
- `"Browser: failed to open new page"` → session/auth issue with Browserless
- `"Browser: failed to navigate to ..."` → page load timeout or navigation error

## Test plan
- [x] 142/142 tests pass
- [x] Build clean
- [ ] Deploy preview → run against JS-rendered site → confirm readable error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)