### PR TITLE
feat: per-page client orchestration to bypass Vercel 60s timeout (#47)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -24,6 +24,41 @@
 
 ## Entries
 
+### [feat/issue-47-per-page-orchestration] Per-page client orchestration — 2026-03-22 [DONE]
+
+**Problem:** Single `/api/clone` SSE route ran the full pipeline in one serverless call. On Vercel Hobby (60s hard limit), a 3-page Sonnet run (3 × ~15s compose + ~15s setup) regularly hit the ceiling.
+
+**Solution:** Split into two bounded endpoints. Client orchestrates the page loop.
+
+- **`GET /api/prepare`** — scrape both sites (with browser fallback), discover pages, extract design system + all page contents → returns JSON. Target: <30s worst case (two browser scrapes in series).
+- **`POST /api/compose`** — receives design system + one page content, runs one Claude call, streams SSE (`status` → `progress*` → `page_complete`). Target: <40s per page on Sonnet.
+
+**Vercel timeout note:** `maxDuration: 60` is the correct value for Hobby — not a mistake. The fix works because each individual call now fits within 60s. If the plan upgrades to Pro, increase compose to 300s at that time.
+
+**Client changes (`page.tsx` `startClone` only):**
+- Calls `/api/prepare` once (JSON); pushes synthetic status/warning events locally
+- Loops `/api/compose` once per page; streams each SSE response through `readComposeStream` helper
+- Emits one synthetic `done` event after all pages complete
+- `readComposeStream` filters per-compose `done` events + flushes residual buffer on stream close
+- AbortController shared across all fetches; Stop button aborts in-flight call and exits loop
+
+**Files added:**
+- `src/app/api/prepare/route.ts` + `__tests__/route.test.ts` (13 tests)
+- `src/app/api/compose/route.ts` + `__tests__/route.test.ts` (15 tests)
+
+**Files modified:**
+- `src/app/page.tsx` — `startClone` function replaced; all state, JSX, and other handlers untouched
+- `vercel.json` — `maxDuration: 60` added for both new routes
+- `DEVLOG.md`
+
+**Files intentionally untouched:**
+- `src/app/api/clone/route.ts` — preserved as rollback target; client no longer calls it
+- All lib files, all components
+
+**Test count:** 144 → 172 (+28)
+
+---
+
 ### [fix/browser-scraper-diagnostics] Fix Browserless v2 WS path — 2026-03-22 [DONE]
 
 **Root cause identified from Railway logs:**

--- a/src/app/api/compose/__tests__/route.test.ts
+++ b/src/app/api/compose/__tests__/route.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/composer', () => ({
+  composePage: vi.fn(),
+}))
+
+import { POST } from '../route'
+import { composePage } from '@/lib/composer'
+import type { ScrapedSite, DiscoveredPage, DesignSystem, PageContent } from '@/lib/types'
+
+const mockComposePage = vi.mocked(composePage)
+
+const fakeSite: ScrapedSite = { url: 'https://example.com', html: '<html/>', css: '', title: 'Test', jsRendered: false }
+void fakeSite // used as reference fixture only
+
+const fakePages: DiscoveredPage[] = [
+  { url: 'https://example.com/', title: 'Home', slug: 'index', navLabel: 'Home' },
+]
+const fakeDesign: DesignSystem = {
+  cssVariables: '',
+  colorPalette: [], fontStack: [], spacing: [], borderRadius: [],
+  componentPatterns: { nav: '', hero: '', footer: '', card: '', button: '' },
+  rawCss: '',
+}
+const fakeContent: PageContent = {
+  url: 'https://example.com/', title: 'Home', slug: 'index',
+  headings: [], paragraphs: [], listItems: [], ctaTexts: [], imageAlts: [], metaDescription: '',
+}
+const fakeHtml = '<!DOCTYPE html><html><body>Hello</body></html>'
+
+function makeRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new Request('http://localhost:3000/api/compose', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  })
+}
+
+async function collectStream(response: Response): Promise<string> {
+  const text = await response.text()
+  return text
+}
+
+function parseEvents(raw: string) {
+  return raw
+    .split('\n\n')
+    .filter(Boolean)
+    .map((line) => {
+      const data = line.replace(/^data: /, '')
+      try { return JSON.parse(data) } catch { return null }
+    })
+    .filter(Boolean)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.ANTHROPIC_API_KEY
+})
+
+describe('POST /api/compose', () => {
+  it('returns 401 when no API key is available', async () => {
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when body is malformed JSON', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    const res = await POST(new Request('http://localhost:3000/api/compose', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when designSystem is missing from body', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    const res = await POST(makeRequest({ pageContent: fakeContent, allPages: fakePages }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when pageContent is missing from body', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    const res = await POST(makeRequest({ designSystem: fakeDesign, allPages: fakePages }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when allPages is not an array', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: 'not-array' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 with Content-Type text/event-stream on valid request', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages, model: 'claude-haiku-4-5-20251001' }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    await collectStream(res)
+  })
+
+  it('streams status event containing navLabel', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages, model: 'claude-haiku-4-5-20251001' }))
+    const raw = await collectStream(res)
+    const events = parseEvents(raw)
+    const statusEvent = events.find((e: { type: string }) => e.type === 'status')
+
+    expect(statusEvent).toBeDefined()
+    expect(statusEvent.message).toContain('Home')
+  })
+
+  it('streams page_complete event with correct fields', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages, model: 'claude-haiku-4-5-20251001' }))
+    const raw = await collectStream(res)
+    const events = parseEvents(raw)
+    const pageCompleteEvent = events.find((e: { type: string }) => e.type === 'page_complete')
+
+    expect(pageCompleteEvent).toBeDefined()
+    expect(pageCompleteEvent.page.slug).toBe(fakeContent.slug)
+    expect(pageCompleteEvent.page.title).toBe(fakeContent.title)
+    expect(pageCompleteEvent.page.navLabel).toBe('Home')
+    expect(pageCompleteEvent.page.html).toBe(fakeHtml)
+    expect(pageCompleteEvent.page.generatedAt).toBeDefined()
+  })
+
+  it('falls back to slug for navLabel when title is empty and no allPages match', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const emptyTitleContent: PageContent = { ...fakeContent, title: '', slug: 'about' }
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: emptyTitleContent, allPages: [], model: 'claude-haiku-4-5-20251001' }))
+    const raw = await collectStream(res)
+    const events = parseEvents(raw)
+    const statusEvent = events.find((e: { type: string }) => e.type === 'status')
+
+    expect(statusEvent).toBeDefined()
+    expect(statusEvent.message).toContain('about')
+    expect(statusEvent.message).not.toContain('undefined')
+  })
+
+  it('does not stream a done event', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages, model: 'claude-haiku-4-5-20251001' }))
+    const raw = await collectStream(res)
+    const events = parseEvents(raw)
+
+    expect(events.find((e: { type: string }) => e.type === 'done')).toBeUndefined()
+  })
+
+  it('streams error event when composePage throws', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockComposePage.mockRejectedValue(new Error('Claude error'))
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages, model: 'claude-haiku-4-5-20251001' }))
+    const raw = await collectStream(res)
+    const events = parseEvents(raw)
+    const errorEvent = events.find((e: { type: string }) => e.type === 'error')
+
+    expect(errorEvent).toBeDefined()
+    expect(errorEvent.error).toMatch(/Claude error/)
+  })
+
+  it('calls composePage with the byok key', async () => {
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest(
+      { designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages },
+      { 'x-api-key': 'byok-key' }
+    ))
+    await collectStream(res)
+    expect(mockComposePage).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), 'byok-key', expect.any(String)
+    )
+  })
+
+  it('calls composePage with env key when no x-api-key header', async () => {
+    process.env.ANTHROPIC_API_KEY = 'env-key'
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages }))
+    await collectStream(res)
+    expect(mockComposePage).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), 'env-key', expect.any(String)
+    )
+  })
+
+  it('uses haiku model when no byok key', async () => {
+    process.env.ANTHROPIC_API_KEY = 'env-key'
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages }))
+    await collectStream(res)
+    expect(mockComposePage).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), expect.any(String), 'claude-haiku-4-5-20251001'
+    )
+  })
+
+  it('uses claude-sonnet-4-6 model when byok key present and no model in body', async () => {
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest(
+      { designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages },
+      { 'x-api-key': 'byok-key' }
+    ))
+    await collectStream(res)
+    expect(mockComposePage).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), expect.any(String), 'claude-sonnet-4-6'
+    )
+  })
+})

--- a/src/app/api/compose/route.ts
+++ b/src/app/api/compose/route.ts
@@ -1,0 +1,90 @@
+import { composePage } from '@/lib/composer'
+import type { CloneEvent, ClonedPage, DesignSystem, DiscoveredPage, PageContent } from '@/lib/types'
+
+const encoder = new TextEncoder()
+
+// TODO: share via a constants module
+const BYOK_MODELS = ['claude-haiku-4-5-20251001', 'claude-sonnet-4-6', 'claude-opus-4-6']
+
+function send(controller: ReadableStreamDefaultController, event: CloneEvent) {
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+}
+
+interface ComposeBody {
+  designSystem: DesignSystem
+  pageContent: PageContent
+  allPages: DiscoveredPage[]
+  model?: string
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const byokKey = request.headers.get('x-api-key')
+  const apiKey = byokKey ?? process.env.ANTHROPIC_API_KEY ?? ''
+
+  if (!apiKey) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  let body: ComposeBody
+  try {
+    body = await request.json()
+  } catch {
+    return new Response('Bad Request', { status: 400 })
+  }
+
+  const { designSystem, pageContent, allPages, model: requestedModel } = body
+
+  if (!designSystem || !pageContent || !Array.isArray(allPages)) {
+    return new Response('Bad Request', { status: 400 })
+  }
+
+  const model = byokKey
+    ? (BYOK_MODELS.includes(requestedModel ?? '') ? requestedModel! : 'claude-sonnet-4-6')
+    : 'claude-haiku-4-5-20251001'
+
+  const navLabel = allPages.find((p) => p.slug === pageContent.slug)?.navLabel || pageContent.title || pageContent.slug
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      send(controller, { type: 'status', message: `Generating ${navLabel}...` })
+
+      const start = Date.now()
+      const tick = setInterval(() => {
+        const s = Math.round((Date.now() - start) / 1000)
+        send(controller, { type: 'progress', message: `Generating ${navLabel}... ${s}s` })
+      }, 2000)
+
+      try {
+        const html = await composePage(designSystem, pageContent, allPages, apiKey, model)
+        clearInterval(tick)
+        const clonedPage: ClonedPage = {
+          slug: pageContent.slug,
+          title: pageContent.title,
+          navLabel,
+          html,
+          generatedAt: new Date().toISOString(),
+        }
+        send(controller, { type: 'page_complete', page: clonedPage })
+      } catch (err) {
+        clearInterval(tick)
+        let message: string
+        if (err instanceof Error) {
+          message = err.message
+        } else {
+          try { message = JSON.stringify(err) ?? 'Unknown error' } catch { message = 'Unknown error' }
+        }
+        send(controller, { type: 'error', error: message })
+      } finally {
+        controller.close()
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  })
+}

--- a/src/app/api/prepare/__tests__/route.test.ts
+++ b/src/app/api/prepare/__tests__/route.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/scraper', () => ({
+  scrapeSite: vi.fn(),
+}))
+vi.mock('@/lib/browserScraper', () => ({
+  scrapeWithBrowser: vi.fn(),
+}))
+vi.mock('@/lib/discover', () => ({
+  discoverPages: vi.fn(),
+}))
+vi.mock('@/lib/extractor', () => ({
+  extractDesignSystem: vi.fn(),
+  extractPageContent: vi.fn(),
+}))
+
+import { GET } from '../route'
+import { scrapeSite } from '@/lib/scraper'
+import { scrapeWithBrowser } from '@/lib/browserScraper'
+import { discoverPages } from '@/lib/discover'
+import { extractDesignSystem, extractPageContent } from '@/lib/extractor'
+import type { ScrapedSite, DiscoveredPage, DesignSystem, PageContent } from '@/lib/types'
+
+const mockScrapeSite = vi.mocked(scrapeSite)
+const mockScrapeWithBrowser = vi.mocked(scrapeWithBrowser)
+const mockDiscoverPages = vi.mocked(discoverPages)
+const mockExtractDesignSystem = vi.mocked(extractDesignSystem)
+const mockExtractPageContent = vi.mocked(extractPageContent)
+
+const fakeSite: ScrapedSite = { url: 'https://example.com', html: '<html/>', css: '', title: 'Test', jsRendered: false }
+const fakePages: DiscoveredPage[] = [
+  { url: 'https://example.com/', title: 'Home', slug: 'index', navLabel: 'Home' },
+]
+const fakeDesign: DesignSystem = {
+  cssVariables: '',
+  colorPalette: [], fontStack: [], spacing: [], borderRadius: [],
+  componentPatterns: { nav: '', hero: '', footer: '', card: '', button: '' },
+  rawCss: '',
+}
+const fakeContent: PageContent = {
+  url: 'https://example.com/', title: 'Home', slug: 'index',
+  headings: [], paragraphs: [], listItems: [], ctaTexts: [], imageAlts: [], metaDescription: '',
+}
+
+function makeRequest(params: Record<string, string>, headers: Record<string, string> = {}) {
+  const url = new URL('http://localhost:3000/api/prepare')
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return new Request(url.toString(), { headers })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.ANTHROPIC_API_KEY
+})
+
+describe('GET /api/prepare', () => {
+  it('returns 400 when designUrl is missing', async () => {
+    const res = await GET(makeRequest({ contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when contentUrl is missing', async () => {
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 401 when no API key is available', async () => {
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with JSON body on success', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('response body contains designSystem, pages, pageContents, warnings, model fields', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    const body = await res.json()
+    expect(body).toHaveProperty('designSystem')
+    expect(body).toHaveProperty('pages')
+    expect(body).toHaveProperty('pageContents')
+    expect(body).toHaveProperty('warnings')
+    expect(body).toHaveProperty('model')
+  })
+
+  it('pageContents length equals pages length', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    const twoPages: DiscoveredPage[] = [
+      { url: 'https://example.com/', title: 'Home', slug: 'index', navLabel: 'Home' },
+      { url: 'https://example.com/about', title: 'About', slug: 'about', navLabel: 'About' },
+    ]
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(twoPages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    const body = await res.json()
+    expect(body.pageContents.length).toBe(2)
+    expect(mockExtractPageContent).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses ANTHROPIC_API_KEY env as fallback', async () => {
+    process.env.ANTHROPIC_API_KEY = 'env-key'
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('x-api-key header takes precedence over env var', async () => {
+    process.env.ANTHROPIC_API_KEY = 'env-key'
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest(
+      { designUrl: 'https://stripe.com', contentUrl: 'https://example.com' },
+      { 'x-api-key': 'byok-key' }
+    ))
+    expect(res.status).toBe(200)
+  })
+
+  it('resolved model is claude-haiku when no byok key', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    const body = await res.json()
+    expect(body.model).toBe('claude-haiku-4-5-20251001')
+  })
+
+  it('resolved model is claude-sonnet-4-6 when byok key with no model param', async () => {
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest(
+      { designUrl: 'https://stripe.com', contentUrl: 'https://example.com' },
+      { 'x-api-key': 'byok-key' }
+    ))
+    const body = await res.json()
+    expect(body.model).toBe('claude-sonnet-4-6')
+  })
+
+  it('resolved model is requested model when byok key and valid model param', async () => {
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest(
+      { designUrl: 'https://stripe.com', contentUrl: 'https://example.com', model: 'claude-opus-4-6' },
+      { 'x-api-key': 'byok-key' }
+    ))
+    const body = await res.json()
+    expect(body.model).toBe('claude-opus-4-6')
+  })
+
+  it('warnings contains jsRendered message when design site is jsRendered', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    const jsRenderedSite: ScrapedSite = { ...fakeSite, jsRendered: true }
+    mockScrapeSite.mockResolvedValueOnce(jsRenderedSite).mockResolvedValueOnce(fakeSite)
+    mockScrapeWithBrowser.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    const body = await res.json()
+    const match = body.warnings.some((w: string) => /Detected JS rendering on design site/.test(w))
+    expect(match).toBe(true)
+    expect(mockScrapeWithBrowser).toHaveBeenCalled()
+  })
+
+  it('returns 500 when scrapeSite throws', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockScrapeSite.mockRejectedValue(new Error('Network failure'))
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/prepare/route.ts
+++ b/src/app/api/prepare/route.ts
@@ -1,0 +1,72 @@
+import { scrapeSite } from '@/lib/scraper'
+import { scrapeWithBrowser } from '@/lib/browserScraper'
+import { discoverPages } from '@/lib/discover'
+import { extractDesignSystem, extractPageContent } from '@/lib/extractor'
+import type { DesignSystem, DiscoveredPage, PageContent } from '@/lib/types'
+
+// TODO: share via a constants module
+const BYOK_MODELS = ['claude-haiku-4-5-20251001', 'claude-sonnet-4-6', 'claude-opus-4-6']
+
+interface PrepareResult {
+  designSystem: DesignSystem
+  pages: DiscoveredPage[]
+  pageContents: PageContent[]
+  warnings: string[]
+  model: string
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url)
+  const designUrl = searchParams.get('designUrl')
+  const contentUrl = searchParams.get('contentUrl')
+
+  if (!designUrl || !contentUrl) {
+    return new Response('Missing parameters', { status: 400 })
+  }
+
+  const byokKey = request.headers.get('x-api-key')
+  const apiKey = byokKey ?? process.env.ANTHROPIC_API_KEY ?? ''
+
+  if (!apiKey) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const requestedModel = searchParams.get('model') ?? ''
+  const model = byokKey
+    ? (BYOK_MODELS.includes(requestedModel) ? requestedModel : 'claude-sonnet-4-6')
+    : 'claude-haiku-4-5-20251001'
+
+  const maxPages = parseInt(process.env.DEMO_PAGE_LIMIT ?? '6')
+  const warnings: string[] = []
+
+  try {
+    let designSite = await scrapeSite(designUrl)
+    if (designSite.jsRendered) {
+      warnings.push('Detected JS rendering on design site — retrying with browser...')
+      designSite = await scrapeWithBrowser(designUrl)
+    }
+
+    let contentSite = await scrapeSite(contentUrl)
+    if (contentSite.jsRendered) {
+      warnings.push('Detected JS rendering on content site — retrying with browser...')
+      contentSite = await scrapeWithBrowser(contentUrl)
+    }
+
+    const pages = discoverPages(contentSite, maxPages)
+    const designSystem = extractDesignSystem(designSite)
+    const pageContents = pages.map((page) => extractPageContent(contentSite, page))
+
+    const result: PrepareResult = { designSystem, pages, pageContents, warnings, model }
+    return new Response(JSON.stringify(result), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    let message: string
+    if (err instanceof Error) {
+      message = err.message
+    } else {
+      try { message = JSON.stringify(err) ?? 'Unknown error' } catch { message = 'Unknown error' }
+    }
+    return new Response(message, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { CloneEvent, ClonedPage } from '@/lib/types'
+import type { CloneEvent, ClonedPage, DiscoveredPage } from '@/lib/types'
 import { getDemoSession, incrementDemoRun, getByokSession, saveByokSession, clearByokSession } from '@/lib/demo'
 import UrlInputPanel from '@/components/UrlInputPanel'
 import ProgressFeed from '@/components/ProgressFeed'
@@ -55,75 +55,115 @@ export default function Home() {
     const headers: Record<string, string> = {}
     if (apiKey) headers['x-api-key'] = apiKey
 
-    const params = new URLSearchParams({ designUrl, contentUrl, model })
+    function pushEvent(event: CloneEvent) {
+      setEvents((prev) => [...prev, event])
+    }
 
-    try {
-      const res = await fetch(`/api/clone?${params}`, {
-        headers,
-        signal: controller.signal,
-      })
-
-      if (!res.ok || !res.body) {
-        setIsRunning(false)
-        return
-      }
-
-      const reader = res.body.getReader()
+    async function readComposeStream(body: ReadableStream<Uint8Array>): Promise<void> {
+      const reader = body.getReader()
       const decoder = new TextDecoder()
       let buffer = ''
-      let receivedDone = false
-      let receivedError = false
-      let completedPages = 0
-
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
-
         buffer += decoder.decode(value, { stream: true })
         const parts = buffer.split('\n\n')
         buffer = parts.pop() ?? ''
-
         for (const part of parts) {
           const line = part.trim()
           if (!line.startsWith('data: ')) continue
           try {
             const event: CloneEvent = JSON.parse(line.slice(6))
-            setEvents((prev) => [...prev, event])
-
+            if (event.type === 'done') continue
+            pushEvent(event)
             if (event.type === 'page_complete') {
-              completedPages += 1
               setPages((prev) => [...prev, event.page])
               setActiveSlug((prev) => prev ?? event.page.slug)
-            }
-            if (event.type === 'done') {
-              receivedDone = true
-            }
-            if (event.type === 'error') {
-              receivedError = true
             }
           } catch {
             // malformed event — skip
           }
         }
       }
+      // Flush any remaining buffer content not terminated by \n\n
+      const remaining = buffer.trim()
+      if (remaining.startsWith('data: ')) {
+        try {
+          const event: CloneEvent = JSON.parse(remaining.slice(6))
+          if (event.type !== 'done') {
+            pushEvent(event)
+            if (event.type === 'page_complete') {
+              setPages((prev) => [...prev, event.page])
+              setActiveSlug((prev) => prev ?? event.page.slug)
+            }
+          }
+        } catch {
+          // malformed — skip
+        }
+      }
+    }
 
-      if (!receivedDone && !receivedError && !abortRef.current?.signal.aborted) {
-        setEvents(prev => [
-          ...prev,
-          {
-            type: 'warning' as const,
-            message: completedPages > 0
-              ? `Generation stopped — server timeout reached. ${completedPages} page(s) completed and ready to download.`
-              : 'Generation stopped before any pages completed. The server timed out — try fewer pages, or add your own API key for longer runs.',
-          },
-        ])
+    try {
+      pushEvent({ type: 'status', message: 'Scraping and preparing...' })
+
+      const params = new URLSearchParams({ designUrl, contentUrl, model })
+      const prepRes = await fetch(`/api/prepare?${params}`, {
+        headers,
+        signal: controller.signal,
+      })
+
+      if (!prepRes.ok) {
+        const text = await prepRes.text()
+        pushEvent({ type: 'error', error: text || `Prepare failed (${prepRes.status})` })
+        return
       }
-      setIsRunning(false)
+
+      const prepData = await prepRes.json() as {
+        designSystem: unknown
+        pages: DiscoveredPage[]
+        pageContents: unknown[]
+        warnings: string[]
+        model: string
+      }
+      const { designSystem, pages, pageContents, warnings, model: resolvedModel } = prepData
+
+      for (const w of warnings) {
+        pushEvent({ type: 'warning', message: w })
+      }
+      pushEvent({ type: 'status', message: `Found ${pages.length} page(s)` })
+
+      for (let i = 0; i < pages.length; i++) {
+        if (controller.signal.aborted) break
+
+        const composeRes = await fetch('/api/compose', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...headers },
+          body: JSON.stringify({
+            designSystem,
+            pageContent: pageContents[i],
+            allPages: pages,
+            model: resolvedModel,
+          }),
+          signal: controller.signal,
+        })
+
+        if (!composeRes.ok || !composeRes.body) {
+          pushEvent({ type: 'error', error: `Failed to compose page ${i + 1} (${composeRes.status})` })
+          continue
+        }
+
+        await readComposeStream(composeRes.body)
+      }
+
+      if (!controller.signal.aborted) {
+        pushEvent({ type: 'done' })
+      }
     } catch (err: unknown) {
-      // AbortError is intentional — don't surface as an error state
       if (!(err instanceof Error && err.name === 'AbortError')) {
-        setIsRunning(false)
+        pushEvent({ type: 'error', error: err instanceof Error ? err.message : 'Unknown error' })
       }
+    } finally {
+      setIsRunning(false)
     }
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "framework": "nextjs",
   "functions": {
-    "src/app/api/clone/route.ts": {
-      "maxDuration": 60
-    }
+    "src/app/api/clone/route.ts":   { "maxDuration": 60 },
+    "src/app/api/prepare/route.ts": { "maxDuration": 60 },
+    "src/app/api/compose/route.ts": { "maxDuration": 60 }
   }
 }


### PR DESCRIPTION
## Summary

- Single `/api/clone` route was timing out on multi-page Sonnet runs (3 pages × 15s = timeout)
- Split into `/api/prepare` (scrape + extract, JSON response) and `/api/compose` (one Claude call per page, SSE stream)
- Client loops `/api/compose` once per page — each serverless invocation now fits within 60s independently
- Old `/api/clone` route preserved untouched as rollback target

## What changed

**New endpoints:**
- `GET /api/prepare` — scrapes both sites (with JS/browser fallback), discovers pages, extracts design system + all page contents, returns JSON with resolved model
- `POST /api/compose` — receives design system + one page content, runs one Claude call, streams `status` → `progress*` → `page_complete` (no `done` — client emits one final)

**Client (`page.tsx` — `startClone` only):**
- Two-phase fetch loop: prepare once, then compose per page
- `readComposeStream` helper filters per-compose `done` events and flushes residual buffer on stream close
- AbortController shared across all fetches; Stop button works correctly mid-loop
- All state variables, JSX, and other handlers untouched

**Infrastructure:**
- `vercel.json`: `maxDuration: 60` added for both new routes (Hobby cap — each call now fits within it)

## Test plan

- [x] `npm run build` — clean (all 4 routes registered)
- [x] `npm test` — 172/172 passing (+28 new tests: 13 prepare, 15 compose)
- [x] Code review gate — 2 correctness fixes applied (residual SSE buffer flush, navLabel slug fallback)
- [x] Deploy to Vercel staging
- [x] Test 3-page site with Sonnet — confirm no timeout
- [x] Test Stop button mid-run
- [x] Test JS-rendered site (browser scraper path in prepare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)