### PR TITLE
fix: raise CSS extraction limits for visual fidelity

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -24,6 +24,25 @@
 
 ## Entries
 
+### [fix/css-extraction-limits] Raise CSS extraction limits for visual fidelity — 2026-03-22 [DONE]
+
+**Problem:** Cloned pages rendered with correct fonts and layout but no colors, backgrounds, or visual design. Root cause: two constants were too conservative for production-scale CSS.
+
+- `RAW_CSS_LIMIT = 2500` in `composer.ts` — after stripping `:root` blocks, only ~50 lines of CSS reached Claude on sites like Vercel or Stripe (charset decls, resets, basic typography). Brand colors, backgrounds, gradients, and button styles were buried deeper and never seen.
+- `PATTERN_CHAR_LIMIT = 1200` in `extractor.ts` — for Tailwind sites, the visual design lives in class names on elements, not in CSS rules. 1200 chars truncated complex components before all their utility classes were captured.
+
+**Fix:**
+- `RAW_CSS_LIMIT`: 2500 → 8000
+- `PATTERN_CHAR_LIMIT`: 1200 → 2500
+
+**Token cost:** ~+3000 input tokens per compose call (~$0.009/page at Sonnet pricing). Negligible.
+
+**Test update:** Composer truncation test updated (name, input length, assertion) from 2500 to 8000.
+
+**Not addressed here:** Hero selector mis-targeting on complex layouts; JS-only stylesheets (handled by browser scraper).
+
+---
+
 ### [feat/issue-47-per-page-orchestration] Per-page client orchestration — 2026-03-22 [DONE]
 
 **Problem:** Single `/api/clone` SSE route ran the full pipeline in one serverless call. On Vercel Hobby (60s hard limit), a 3-page Sonnet run (3 × ~15s compose + ~15s setup) regularly hit the ceiling.

--- a/src/lib/__tests__/composer.test.ts
+++ b/src/lib/__tests__/composer.test.ts
@@ -77,14 +77,14 @@ describe('composePage', () => {
     ).rejects.toThrow('Claude did not return valid HTML')
   })
 
-  it('truncates rawCss to 2500 characters', async () => {
+  it('truncates rawCss to 8000 characters', async () => {
     mockResponse(validHtml)
-    const longCss = 'a'.repeat(12000)
+    const longCss = 'a'.repeat(20000)
     await composePage(makeDesign(longCss), makeContent(), makePages(), 'test-key', 'claude-haiku-4-5-20251001')
 
     const callArg = mockCreate.mock.calls[0][0]
     const userContent = JSON.parse(callArg.messages[0].content)
-    expect(userContent.designSystem.rawCss.length).toBeLessThanOrEqual(2500)
+    expect(userContent.designSystem.rawCss.length).toBeLessThanOrEqual(8000)
   })
 
   it('includes all page slugs in the navigation array', async () => {

--- a/src/lib/composer.ts
+++ b/src/lib/composer.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk'
 import type { DesignSystem, DiscoveredPage, PageContent } from './types'
 
-const RAW_CSS_LIMIT = 2500
+const RAW_CSS_LIMIT = 8000
 
 const SYSTEM_PROMPT = `You are an expert web developer. Given a design system and page content, build a polished, complete, self-contained HTML page.
 

--- a/src/lib/extractor.ts
+++ b/src/lib/extractor.ts
@@ -4,7 +4,7 @@ import type { DesignSystem, DiscoveredPage, PageContent, ScrapedSite } from './t
 // --- Design System Extraction ---
 
 const CSS_VARIABLE_RE = /:root\s*\{([^}]*)\}/g
-const PATTERN_CHAR_LIMIT = 1200
+const PATTERN_CHAR_LIMIT = 2500
 const COLOR_LIMIT = 20
 
 const MAX_HEADINGS = 12


### PR DESCRIPTION
## Summary

- `RAW_CSS_LIMIT` raised from 2500 → 8000 in `src/lib/composer.ts`
- `PATTERN_CHAR_LIMIT` raised from 1200 → 2500 in `src/lib/extractor.ts`
- Composer truncation test updated to match new limit (name, input, assertion)

## Problem

Cloned pages rendered with correct fonts and layout but no colors, backgrounds, or visual design. Root cause: both constants were too conservative for production-scale CSS.

- At 2500 chars, after stripping `:root` blocks, only ~50 lines of raw CSS reach Claude on sites like Vercel or Stripe — charset declarations, resets, typography. Brand colors, backgrounds, gradients, and button styles are buried deeper and never seen.
- At 1200 chars, Tailwind component patterns get truncated before all utility classes are captured. For Tailwind sites, class names ARE the visual design spec.

Colors were already extracted correctly (`colorPalette` is populated from the full CSS), but Claude had no context for WHERE they're applied. More `rawCss` and fuller component patterns provide that context.

## Token cost

~+3000 input tokens per compose call (~$0.009/page at Sonnet pricing). Negligible.

## Test plan

- [x] `npm test` — 172/172 pass
- [x] `npm run build` — clean
- [ ] Run a Vercel → GitHub clone and compare visual output before/after (manual smoke test on staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)