### PR TITLE
fix: Clerk modal text readability and proxy configuration

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,14 @@
 import { clerkMiddleware } from '@clerk/nextjs/server'
-import { NextResponse } from 'next/server'
-import type { NextRequest, NextFetchEvent } from 'next/server'
 
-export default function middleware(request: NextRequest, event: NextFetchEvent) {
-  if (request.nextUrl.pathname.startsWith('/__clerk')) {
-    const clerkUrl = new URL(
-      request.nextUrl.pathname.replace('/__clerk', '') + request.nextUrl.search,
-      'https://clerk.kaminify.com'
-    )
-    return NextResponse.rewrite(clerkUrl)
-  }
-
-  return clerkMiddleware()(request, event)
-}
+export default clerkMiddleware({
+  frontendApiProxy: {
+    enabled: true,
+  },
+})
 
 export const config = {
   matcher: [
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|ico|png|svg|jpg|jpeg|gif|woff2?|ttf)).*)',
-    '/(api|trpc)(.*)',
-    '/__clerk(.*)',
+    '/(api|trpc|__clerk)(.*)',
   ],
 }


### PR DESCRIPTION
## Summary

- Fix unreadable modal text: Clerk v7 renamed appearance variables (`colorText` → `colorForeground`, `colorInputBackground` → `colorInput`, etc.) — old names were silently ignored, leaving Clerk to default to dark text on a dark background
- Replace hand-rolled `/__clerk` proxy middleware (manual `NextResponse.rewrite` to internal Clerk URL + `any` casts) with the correct `clerkMiddleware({ frontendApiProxy: { enabled: true } })` native v7 API

## Test plan

- [ ] Open sign-in modal — all text readable (labels, inputs, footer links)
- [ ] Social provider buttons readable
- [ ] Clean production build (`npm run build`)
- [ ] Clerk proxy route (`/__clerk`) functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)