### PR TITLE
feat: Phase 2 foundation — Supabase schema, lib/supabase, lib/stripe, lib/quota

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -24,6 +24,30 @@
 
 ## Entries
 
+### [feat/phase2-foundation] Phase 2 Foundation — Supabase + Stripe + Quota — 2026-03-23 [DONE]
+
+**Goal:** Lay the DB and library infrastructure for monetization. No user-facing changes — pure foundation for billing and quota enforcement branches.
+
+**What shipped:**
+- Supabase `users` table: `clerk_user_id`, `stripe_customer_id`, `stripe_subscription_id`, `subscription_status`, `runs_this_month`, `month_start`, timestamps
+- RLS: `users_select_own` policy — reads bound to Clerk JWT `sub` claim
+- SQL function: `increment_runs(p_clerk_user_id)` — atomic counter increment
+- `src/lib/supabase.ts`: `adminClient()` — service role, bypasses RLS, server-only
+- `src/lib/stripe.ts`: `stripe` singleton + `PRICE_ID` constant
+- `src/lib/quota.ts`: `getOrCreateUser`, `getQuotaStatus`, `incrementRun` — month reset on check-on-read
+- `src/lib/types.ts`: added `UserRecord` and `QuotaStatus` interfaces
+- 7 new quota unit tests (189 total passing)
+
+**Key decisions:**
+- Month reset is check-on-read (no cron) — compare stored `month_start` to current UTC month on every `getOrCreateUser` call
+- `FREE_RUN_LIMIT` reads from `DEMO_RUN_LIMIT` env (default 3)
+- Pro tier: `runsLimit: null` (unlimited)
+- All DB writes use service role; RLS only guards client reads
+
+**New deps:** `@supabase/supabase-js`, `@supabase/ssr`, `stripe`
+
+---
+
 ### [feat/demo-pairings-random] Demo pairings refresh + random picker — 2026-03-23 [DONE]
 
 **Problem:** The 4 example pills (Stripe+me, Stripe+GitHub, etc.) were weak and repetitive. No way to discover pairings without manually entering URLs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
         "@clerk/nextjs": "^7.0.6",
+        "@supabase/ssr": "^0.9.0",
+        "@supabase/supabase-js": "^2.100.0",
         "archiver": "^7.0.1",
         "cheerio": "^1.2.0",
         "next": "15.5.14",
         "puppeteer-core": "^24.40.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "stripe": "^20.4.1",
         "three": "^0.183.2"
       },
       "devDependencies": {
@@ -1804,6 +1807,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.0.tgz",
+      "integrity": "sha512-pdT3ye3UVRN1Cg0wom6BmyY+XTtp5DiJaYnPi6j8ht5i8Lq8kfqxJMJz9GI9YDKk3w1nhGOPnh6Qz5qpyYm+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.0.tgz",
+      "integrity": "sha512-keLg79RPwP+uiwHuxFPTFgDRxPV46LM4j/swjyR2GKJgWniTVSsgiBHfbIBDcrQwehLepy09b/9QSHUywtKRWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.0.tgz",
+      "integrity": "sha512-xYNvNbBJaXOGcrZ44wxwp5830uo1okMHGS8h8dm3u4f0xcZ39yzbryUsubTJW41MG2gbL/6U57cA4Pi6YMZ9pA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.0.tgz",
+      "integrity": "sha512-2AZs00zzEF0HuCKY8grz5eCYlwEfVi5HONLZFoNR6aDfxQivl8zdQYNjyFoqN2MZiVhQHD7u6XV/xHwM8mCEHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.9.0.tgz",
+      "integrity": "sha512-UFY6otYV3yqCgV+AyHj80vNkTvbf1Gas2LW4dpbQ4ap6p6v3eB2oaDfcI99jsuJzwVBCFU4BJI+oDYyhNk1z0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.97.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.0.tgz",
+      "integrity": "sha512-d4EeuK6RNIgYNA2MU9kj8lQrLm5AzZ+WwpWjGkii6SADQNIGTC/uiaTRu02XJ5AmFALQfo8fLl9xuCkO6Xw+iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.0.tgz",
+      "integrity": "sha512-r0tlcukejJXJ1m/2eG/Ya5eYs4W8AC7oZfShpG3+SIo/eIU9uIt76ZeYI1SoUwUmcmzlAbgch+HDZDR/toVQPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.100.0",
+        "@supabase/functions-js": "2.100.0",
+        "@supabase/postgrest-js": "2.100.0",
+        "@supabase/realtime-js": "2.100.0",
+        "@supabase/storage-js": "2.100.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2277,7 +2378,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2342,6 +2442,15 @@
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -3980,6 +4089,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -5810,6 +5932,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -8920,6 +9051,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.4.1.tgz",
+      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -9390,7 +9538,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,15 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
     "@clerk/nextjs": "^7.0.6",
+    "@supabase/ssr": "^0.9.0",
+    "@supabase/supabase-js": "^2.100.0",
     "archiver": "^7.0.1",
     "cheerio": "^1.2.0",
     "next": "15.5.14",
     "puppeteer-core": "^24.40.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "stripe": "^20.4.1",
     "three": "^0.183.2"
   },
   "devDependencies": {

--- a/src/lib/__tests__/quota.test.ts
+++ b/src/lib/__tests__/quota.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { UserRecord } from '../types'
+
+// --- Supabase mock -----------------------------------------------------------
+
+type BuilderResult<T> = Promise<{ data: T | null; error: { message: string } | null }>
+
+interface MockBuilder {
+  upsert: (_data: unknown, _opts?: unknown) => Promise<{ error: null }>
+  select: (_cols: string) => MockBuilder
+  eq: (_col: string, _val: string) => MockBuilder
+  single: () => BuilderResult<UserRecord>
+  update: (_data: unknown) => MockBuilder
+  rpc?: (_fn: string, _args: unknown) => Promise<{ error: { message: string } | null }>
+}
+
+function makeSupabaseMock(userRecord: UserRecord, rpcError: { message: string } | null = null) {
+  const fetchSingle = vi.fn().mockResolvedValue({ data: userRecord, error: null })
+  const updateSingle = vi.fn().mockResolvedValue({
+    data: { ...userRecord, runs_this_month: 0, month_start: '2026-03-01' },
+    error: null,
+  })
+
+  // Tracks which chain is in progress so .single() returns the right result
+  let inUpdate = false
+
+  const builder: MockBuilder = {
+    upsert: vi.fn().mockResolvedValue({ error: null }),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockImplementation(() => (inUpdate ? updateSingle() : fetchSingle())),
+    update: vi.fn().mockImplementation(() => {
+      inUpdate = true
+      return builder
+    }),
+  }
+
+  const rpc = vi.fn().mockResolvedValue({ error: rpcError })
+
+  const db = {
+    from: vi.fn().mockReturnValue(builder),
+    rpc,
+  }
+
+  return { db, builder, fetchSingle, updateSingle, rpc }
+}
+
+vi.mock('../supabase', () => ({
+  adminClient: vi.fn(),
+}))
+
+// Import after mock is registered
+import { adminClient } from '../supabase'
+import { getQuotaStatus, getOrCreateUser, incrementRun } from '../quota'
+
+const mockedAdminClient = vi.mocked(adminClient)
+
+// --- Helpers -----------------------------------------------------------------
+
+function makeUser(overrides: Partial<UserRecord> = {}): UserRecord {
+  return {
+    id: 'uuid-1',
+    clerk_user_id: 'user_abc',
+    stripe_customer_id: null,
+    stripe_subscription_id: null,
+    subscription_status: 'free',
+    runs_this_month: 0,
+    month_start: '2026-03-01',
+    created_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// --- getQuotaStatus — free user ----------------------------------------------
+
+describe('getQuotaStatus — free user', () => {
+  it('returns tier: free, runsLimit: 3, canRun: true when runs_this_month = 0', async () => {
+    const { db } = makeSupabaseMock(makeUser({ runs_this_month: 0 }))
+    mockedAdminClient.mockReturnValue(db as unknown as ReturnType<typeof adminClient>)
+
+    const status = await getQuotaStatus('user_abc')
+
+    expect(status.tier).toBe('free')
+    expect(status.runsLimit).toBe(3)
+    expect(status.canRun).toBe(true)
+  })
+
+  it('returns canRun: true when runs_this_month = 2 (under limit)', async () => {
+    const { db } = makeSupabaseMock(makeUser({ runs_this_month: 2 }))
+    mockedAdminClient.mockReturnValue(db as unknown as ReturnType<typeof adminClient>)
+
+    const status = await getQuotaStatus('user_abc')
+
+    expect(status.canRun).toBe(true)
+  })
+
+  it('returns canRun: false when runs_this_month = 3 (at limit)', async () => {
+    const { db } = makeSupabaseMock(makeUser({ runs_this_month: 3 }))
+    mockedAdminClient.mockReturnValue(db as unknown as ReturnType<typeof adminClient>)
+
+    const status = await getQuotaStatus('user_abc')
+
+    expect(status.canRun).toBe(false)
+  })
+})
+
+// --- getQuotaStatus — pro user -----------------------------------------------
+
+describe('getQuotaStatus — pro user', () => {
+  it('returns tier: pro, runsLimit: null, canRun: true regardless of run count', async () => {
+    const { db } = makeSupabaseMock(makeUser({ subscription_status: 'pro', runs_this_month: 999 }))
+    mockedAdminClient.mockReturnValue(db as unknown as ReturnType<typeof adminClient>)
+
+    const status = await getQuotaStatus('user_abc')
+
+    expect(status.tier).toBe('pro')
+    expect(status.runsLimit).toBeNull()
+    expect(status.canRun).toBe(true)
+  })
+})
+
+// --- getOrCreateUser — month reset -------------------------------------------
+
+describe('getOrCreateUser — month reset', () => {
+  it('calls update to reset runs_this_month when month_start is a past month', async () => {
+    const { db, builder } = makeSupabaseMock(makeUser({ month_start: '2026-02-01' }))
+    mockedAdminClient.mockReturnValue(db as unknown as ReturnType<typeof adminClient>)
+
+    await getOrCreateUser('user_abc')
+
+    expect(builder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ runs_this_month: 0 }),
+    )
+  })
+})
+
+// --- incrementRun ------------------------------------------------------------
+
+describe('incrementRun', () => {
+  it('does not call fallback update when RPC succeeds', async () => {
+    const { db, builder } = makeSupabaseMock(makeUser(), null)
+    mockedAdminClient.mockReturnValue(db as unknown as ReturnType<typeof adminClient>)
+
+    await incrementRun('user_abc')
+
+    expect(builder.update).not.toHaveBeenCalled()
+  })
+
+  it('calls fallback update when RPC fails', async () => {
+    const { db, builder } = makeSupabaseMock(makeUser(), { message: 'not found' })
+    mockedAdminClient.mockReturnValue(db as unknown as ReturnType<typeof adminClient>)
+
+    await incrementRun('user_abc')
+
+    expect(builder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ runs_this_month: 1 }),
+    )
+  })
+})

--- a/src/lib/quota.ts
+++ b/src/lib/quota.ts
@@ -1,0 +1,75 @@
+import { adminClient } from './supabase'
+import type { QuotaStatus, UserRecord } from './types'
+
+const FREE_RUN_LIMIT = parseInt(process.env.DEMO_RUN_LIMIT ?? '3', 10)
+
+function currentMonthStart(): string {
+  const now = new Date()
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-01`
+}
+
+// Upsert user row. Resets monthly counter if we've rolled into a new month.
+// Returns the up-to-date user record.
+export async function getOrCreateUser(clerkUserId: string): Promise<UserRecord> {
+  const db = adminClient()
+  const monthStart = currentMonthStart()
+
+  // Upsert — creates row on first call, no-op on conflict
+  const { error: upsertError } = await db
+    .from('users')
+    .upsert({ clerk_user_id: clerkUserId }, { onConflict: 'clerk_user_id', ignoreDuplicates: true })
+
+  if (upsertError) throw new Error(`upsert user: ${upsertError.message}`)
+
+  // Fetch current state
+  const { data, error: fetchError } = await db
+    .from('users')
+    .select('*')
+    .eq('clerk_user_id', clerkUserId)
+    .single()
+
+  if (fetchError || !data) throw new Error(`fetch user: ${fetchError?.message}`)
+
+  // Reset counter if we're in a new month
+  if (data.month_start < monthStart) {
+    const { data: reset, error: resetError } = await db
+      .from('users')
+      .update({ runs_this_month: 0, month_start: monthStart })
+      .eq('clerk_user_id', clerkUserId)
+      .select('*')
+      .single()
+
+    if (resetError || !reset) throw new Error(`reset month: ${resetError?.message}`)
+    return reset as UserRecord
+  }
+
+  return data as UserRecord
+}
+
+// Returns quota status for a signed-in user.
+export async function getQuotaStatus(clerkUserId: string): Promise<QuotaStatus> {
+  const user = await getOrCreateUser(clerkUserId)
+  const isPro = user.subscription_status === 'pro'
+
+  return {
+    tier: isPro ? 'pro' : 'free',
+    runsUsed: user.runs_this_month,
+    runsLimit: isPro ? null : FREE_RUN_LIMIT,
+    canRun: isPro || user.runs_this_month < FREE_RUN_LIMIT,
+  }
+}
+
+// Increment run count for a signed-in user.
+export async function incrementRun(clerkUserId: string): Promise<void> {
+  const db = adminClient()
+  const { error } = await db.rpc('increment_runs', { p_clerk_user_id: clerkUserId })
+  if (error) {
+    // Fallback: manual increment if RPC not available
+    const user = await getOrCreateUser(clerkUserId)
+    const { error: updateError } = await db
+      .from('users')
+      .update({ runs_this_month: user.runs_this_month + 1 })
+      .eq('clerk_user_id', clerkUserId)
+    if (updateError) throw new Error(`increment run: ${updateError.message}`)
+  }
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,7 @@
+import Stripe from 'stripe'
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2025-01-27.acacia' as Stripe.LatestApiVersion,
+})
+
+export const PRICE_ID = process.env.STRIPE_PRICE_ID!

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Service role client — bypasses RLS. Server-only. Never expose to browser.
+export function adminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,3 +83,24 @@ export interface ByokSession {
   apiKey: string   // user's Anthropic key
   addedAt: string
 }
+
+// DB user record
+export interface UserRecord {
+  id: string
+  clerk_user_id: string
+  stripe_customer_id: string | null
+  stripe_subscription_id: string | null
+  subscription_status: 'free' | 'pro'
+  runs_this_month: number
+  month_start: string  // ISO date YYYY-MM-DD
+  created_at: string
+  updated_at: string
+}
+
+// Quota status returned by lib/quota.ts
+export interface QuotaStatus {
+  tier: 'anon' | 'free' | 'pro'
+  runsUsed: number
+  runsLimit: number | null  // null = unlimited
+  canRun: boolean
+}


### PR DESCRIPTION
## Summary
- Supabase `users` table with RLS + `increment_runs` SQL function (applied via MCP migration)
- `lib/supabase.ts` — `adminClient()` service role client (server-only, bypasses RLS)
- `lib/stripe.ts` — `stripe` singleton + `PRICE_ID` constant
- `lib/quota.ts` — `getOrCreateUser`, `getQuotaStatus`, `incrementRun` with check-on-read month reset
- `UserRecord` + `QuotaStatus` types added to `lib/types.ts`
- 7 new quota unit tests — 189 total passing, build and lint clean

## No user-facing changes
Pure infrastructure for `feat/phase2-billing` and `feat/phase2-quota` branches.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 189 passing
- [x] Supabase Dashboard → Table Editor → `users` table exists with correct columns
- [x] Supabase Dashboard → Database → Functions → `increment_runs` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)