### PR TITLE
fix: hide My Sites for unauthenticated users, implement regenerate endpoint

### DIFF
--- a/src/app/api/sites/[id]/regenerate/__tests__/route.test.ts
+++ b/src/app/api/sites/[id]/regenerate/__tests__/route.test.ts
@@ -54,7 +54,8 @@ async function callRoute(siteId: string, headers: Record<string, string> = {}) {
 beforeEach(() => {
   vi.clearAllMocks()
   delete process.env.ANTHROPIC_API_KEY
-  mockAuth.mockResolvedValue({ userId: null } as any)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockAuth.mockImplementation(() => Promise.resolve({ userId: null } as any) as any)
   mockAdminClient.mockReturnValue({
     from: vi.fn().mockReturnValue({
       select: vi.fn().mockReturnValue({
@@ -79,7 +80,8 @@ describe('POST /api/sites/:id/regenerate', () => {
   })
 
   it('returns 401 when no API key available (signed-in user with no key, no BYOK header, no env key)', async () => {
-    mockAuth.mockResolvedValue({ userId: 'user-1' } as any)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockAuth.mockImplementation(() => Promise.resolve({ userId: 'user-1' }) as any)
     mockGetSite.mockResolvedValue(fakeSite)
     const res = await callRoute('site-1', { Authorization: 'Bearer user-token' })
     expect(res.status).toBe(401)
@@ -113,7 +115,8 @@ describe('POST /api/sites/:id/regenerate', () => {
 
   it('returns 200 when signed-in user has stored encrypted API key', async () => {
     process.env.ANTHROPIC_API_KEY = ''
-    mockAuth.mockResolvedValue({ userId: 'user-1' } as any)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockAuth.mockImplementation(() => Promise.resolve({ userId: 'user-1' }) as any)
     mockGetSite.mockResolvedValue(fakeSite)
     mockDeserialiseEncryptedKey.mockReturnValue({ ciphertext: 'abc', iv: 'def', authTag: 'ghi' })
     mockDecryptApiKey.mockReturnValue('sk-ant-decrypted-key')
@@ -139,7 +142,8 @@ describe('POST /api/sites/:id/regenerate', () => {
 
   it('returns 200 and uses env key when stored key decrypt fails', async () => {
     process.env.ANTHROPIC_API_KEY = 'sk-ant-server-key'
-    mockAuth.mockResolvedValue({ userId: 'user-1' } as any)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockAuth.mockImplementation(() => Promise.resolve({ userId: 'user-1' }) as any)
     mockGetSite.mockResolvedValue(fakeSite)
     mockDeserialiseEncryptedKey.mockReturnValue({ ciphertext: 'abc', iv: 'def', authTag: 'ghi' })
     mockDecryptApiKey.mockImplementation(() => { throw new Error('decrypt failed') })

--- a/src/app/api/sites/[id]/regenerate/__tests__/route.test.ts
+++ b/src/app/api/sites/[id]/regenerate/__tests__/route.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/site-storage', () => ({
+  getSite: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  adminClient: vi.fn(),
+}))
+
+vi.mock('@/lib/api-key-crypto', () => ({
+  deserialiseEncryptedKey: vi.fn(),
+  decryptApiKey: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+}))
+
+import { POST } from '../route'
+import { getSite } from '@/lib/site-storage'
+import { adminClient } from '@/lib/supabase'
+import { deserialiseEncryptedKey, decryptApiKey } from '@/lib/api-key-crypto'
+import { auth } from '@clerk/nextjs/server'
+
+const mockAuth = vi.mocked(auth)
+const mockGetSite = vi.mocked(getSite)
+const mockAdminClient = vi.mocked(adminClient)
+const mockDeserialiseEncryptedKey = vi.mocked(deserialiseEncryptedKey)
+const mockDecryptApiKey = vi.mocked(decryptApiKey)
+
+const fakeSite = {
+  id: 'site-1',
+  user_id: 'user-1',
+  session_id: null,
+  name: 'Test Site',
+  design_url: 'https://stripe.com',
+  content_url: 'https://tailwindcss.com',
+  model: 'claude-sonnet-4-6',
+  page_count: 1,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  deleted_at: null,
+}
+
+async function callRoute(siteId: string, headers: Record<string, string> = {}) {
+  const req = new Request(`http://localhost:3000/api/sites/${siteId}/regenerate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+  return POST(req as Request, { params: Promise.resolve({ id: siteId }) })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.ANTHROPIC_API_KEY
+  mockAuth.mockResolvedValue({ userId: null } as any)
+  mockAdminClient.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
+    }),
+  } as unknown as ReturnType<typeof adminClient>)
+})
+
+describe('POST /api/sites/:id/regenerate', () => {
+  it('returns 401 when no auth and no sessionId', async () => {
+    const res = await callRoute('site-1')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when site not found', async () => {
+    mockGetSite.mockResolvedValue(null)
+    const res = await callRoute('nonexistent', { 'x-session-id': 'session-1' })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 401 when no API key available (signed-in user with no key, no BYOK header, no env key)', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-1' } as any)
+    mockGetSite.mockResolvedValue(fakeSite)
+    const res = await callRoute('site-1', { Authorization: 'Bearer user-token' })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toBe('No API key available')
+  })
+
+  it('returns 200 with stored URLs when server env key is available', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-server-key'
+    mockGetSite.mockResolvedValue(fakeSite)
+    const res = await callRoute('site-1', { 'x-session-id': 'session-1' })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.siteId).toBe('site-1')
+    expect(json.designUrl).toBe('https://stripe.com')
+    expect(json.contentUrl).toBe('https://tailwindcss.com')
+    expect(json.model).toBe('claude-sonnet-4-6')
+  })
+
+  it('returns 200 with stored URLs when BYOK header is provided', async () => {
+    mockGetSite.mockResolvedValue(fakeSite)
+    const res = await callRoute('site-1', {
+      'x-session-id': 'session-1',
+      'x-api-key': 'sk-ant-user-key',
+    })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.designUrl).toBe('https://stripe.com')
+    expect(json.contentUrl).toBe('https://tailwindcss.com')
+  })
+
+  it('returns 200 when signed-in user has stored encrypted API key', async () => {
+    process.env.ANTHROPIC_API_KEY = ''
+    mockAuth.mockResolvedValue({ userId: 'user-1' } as any)
+    mockGetSite.mockResolvedValue(fakeSite)
+    mockDeserialiseEncryptedKey.mockReturnValue({ ciphertext: 'abc', iv: 'def', authTag: 'ghi' })
+    mockDecryptApiKey.mockReturnValue('sk-ant-decrypted-key')
+    mockAdminClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { api_key: '{"ciphertext":"abc","iv":"def","authTag":"ghi"}' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof adminClient>)
+    const res = await callRoute('site-1', { Authorization: 'Bearer user-token' })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.siteId).toBe('site-1')
+    expect(mockDeserialiseEncryptedKey).toHaveBeenCalled()
+    expect(mockDecryptApiKey).toHaveBeenCalled()
+  })
+
+  it('returns 200 and uses env key when stored key decrypt fails', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-server-key'
+    mockAuth.mockResolvedValue({ userId: 'user-1' } as any)
+    mockGetSite.mockResolvedValue(fakeSite)
+    mockDeserialiseEncryptedKey.mockReturnValue({ ciphertext: 'abc', iv: 'def', authTag: 'ghi' })
+    mockDecryptApiKey.mockImplementation(() => { throw new Error('decrypt failed') })
+    mockAdminClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { api_key: '{"ciphertext":"abc","iv":"def","authTag":"ghi"}' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof adminClient>)
+    const res = await callRoute('site-1', { Authorization: 'Bearer user-token' })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.siteId).toBe('site-1')
+  })
+
+  it('returns 500 when getSite throws', async () => {
+    mockGetSite.mockRejectedValue(new Error('DB error'))
+    const res = await callRoute('site-1', { 'x-session-id': 'session-1' })
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json.error).toBe('DB error')
+  })
+})

--- a/src/app/api/sites/[id]/regenerate/route.ts
+++ b/src/app/api/sites/[id]/regenerate/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server'
 import { getSite } from '@/lib/site-storage'
 import { adminClient } from '@/lib/supabase'
+import { deserialiseEncryptedKey, decryptApiKey } from '@/lib/api-key-crypto'
 
 export async function POST(
   request: Request,
@@ -26,7 +27,7 @@ export async function POST(
       })
     }
 
-    // Get the user's API key
+    // Resolve API key for this user
     let effectiveApiKey = process.env.ANTHROPIC_API_KEY ?? ''
     if (userId) {
       const { data: user } = await adminClient()
@@ -35,7 +36,12 @@ export async function POST(
         .eq('clerk_user_id', userId)
         .single()
       if (user?.api_key) {
-        effectiveApiKey = user.api_key
+        try {
+          const encrypted = deserialiseEncryptedKey(user.api_key)
+          effectiveApiKey = decryptApiKey(encrypted)
+        } catch {
+          // Decrypt failed — fall through to env key
+        }
       }
     }
 
@@ -49,20 +55,13 @@ export async function POST(
       })
     }
 
-    // TODO: This is a stub. Full implementation would re-run the full prepare+compose pipeline.
-    // For now, return the site's stored URLs so the client can re-initiate.
-    // A proper implementation would:
-    // 1. Re-scrape both URLs
-    // 2. Re-extract design system and page content
-    // 3. Create a new run
-    // 4. Stream SSE page_complete events back to client
     return new Response(JSON.stringify({
-      message: 'Regenerate not yet implemented — please re-run from the home page with the same URLs',
+      siteId: site.id,
       designUrl: site.design_url,
       contentUrl: site.content_url,
       model: site.model,
     }), {
-      status: 501,
+      status: 200,
       headers: { 'Content-Type': 'application/json' },
     })
   } catch (err) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,7 @@ export default function Home() {
   const [mySites, setMySites] = useState<(Site & { runs?: Run[] })[]>([])
   const [loadingSites, setLoadingSites] = useState(false)
   const [expandedSiteId, setExpandedSiteId] = useState<string | null>(null)
+  const [regeneratingFrom, setRegeneratingFrom] = useState<(Site & { runs?: Run[] }) | null>(null)
   const abortRef = useRef<AbortController | null>(null)
 
   // Hydrate quota state from server for signed-in users; sessionStorage for anonymous
@@ -91,6 +92,20 @@ export default function Home() {
   useEffect(() => {
     setSessionId(getOrCreateSessionId())
   }, [])
+
+  // Auto-trigger clone when user clicks "Regenerate" on a saved site
+  useEffect(() => {
+    if (regeneratingFrom) {
+      setModel(regeneratingFrom.model)
+      // Use setTimeout to let React flush the state update first
+      const timeout = setTimeout(() => {
+        if (regeneratingFrom) {
+          startClone(regeneratingFrom.design_url, regeneratingFrom.content_url)
+        }
+      }, 0)
+      return () => clearTimeout(timeout)
+    }
+  }, [regeneratingFrom]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return () => { abortRef.current?.abort() }
@@ -438,17 +453,19 @@ export default function Home() {
           Clone any site&apos;s design. Keep your content.
         </span>
         <div className="ml-auto flex items-center gap-3">
-          <button
-            onClick={openMySites}
-            className="text-xs px-3 py-1.5 rounded-md border transition-colors"
-            style={{
-              color: 'var(--color-text-secondary)',
-              borderColor: 'var(--color-border-bright)',
-              backgroundColor: 'transparent',
-            }}
-          >
-            My Sites
-          </button>
+          {isSignedIn && (
+            <button
+              onClick={openMySites}
+              className="text-xs px-3 py-1.5 rounded-md border transition-colors"
+              style={{
+                color: 'var(--color-text-secondary)',
+                borderColor: 'var(--color-border-bright)',
+                backgroundColor: 'transparent',
+              }}
+            >
+              My Sites
+            </button>
+          )}
           {isSignedIn && apiKey && (
             <button
               onClick={handleClearApiKey}
@@ -555,6 +572,9 @@ export default function Home() {
           model={model}
           onModelChange={setModel}
           hasApiKey={!!apiKey}
+          prefillDesign={regeneratingFrom?.design_url}
+          prefillContent={regeneratingFrom?.content_url}
+          onPrefillConsumed={() => setRegeneratingFrom(null)}
         />
         {!isRunning && pages.length > 0 && (
           <div className="mt-4 flex justify-end">
@@ -697,6 +717,21 @@ export default function Home() {
                         >
                           {expandedSiteId === site.id ? 'Hide' : 'Show'} runs
                         </button>
+                        {isSignedIn && (
+                          <button
+                            onClick={() => {
+                              setRegeneratingFrom(site as Site & { runs?: Run[] })
+                              setShowMySites(false)
+                            }}
+                            className="text-xs px-3 py-1 rounded border transition-colors"
+                            style={{
+                              borderColor: 'var(--color-border-bright)',
+                              color: 'var(--color-text-secondary)',
+                            }}
+                          >
+                            Regenerate
+                          </button>
+                        )}
                         <button
                           onClick={() => {
                             const newName = window.prompt('Rename site:', site.name)

--- a/src/components/UrlInputPanel.tsx
+++ b/src/components/UrlInputPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 interface UrlInputPanelProps {
   onClone: (designUrl: string, contentUrl: string) => void
@@ -9,6 +9,10 @@ interface UrlInputPanelProps {
   model: string
   onModelChange: (model: string) => void
   hasApiKey: boolean
+  // For pre-filling URLs from site regeneration
+  prefillDesign?: string
+  prefillContent?: string
+  onPrefillConsumed?: () => void
 }
 
 const MODEL_OPTIONS = [
@@ -49,11 +53,39 @@ function validateUrl(v: string): string {
   }
 }
 
-export default function UrlInputPanel({ onClone, isRunning, disabled, model, onModelChange, hasApiKey }: UrlInputPanelProps) {
+export default function UrlInputPanel({ onClone, isRunning, disabled, model, onModelChange, hasApiKey, prefillDesign, prefillContent, onPrefillConsumed }: UrlInputPanelProps) {
   const [designUrl, setDesignUrl] = useState('')
   const [contentUrl, setContentUrl] = useState('')
   const [designError, setDesignError] = useState('')
   const [contentError, setContentError] = useState('')
+  const prefillConsumedRef = useRef(false)
+
+  // Pre-fill URLs when regenerating a saved site
+  useEffect(() => {
+    if (prefillDesign && prefillDesign !== designUrl) {
+      setDesignUrl(prefillDesign)
+      setDesignError('')
+    }
+  }, [prefillDesign]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (prefillContent && prefillContent !== contentUrl) {
+      setContentUrl(prefillContent)
+      setContentError('')
+    }
+    // Signal parent once both URLs are populated and clone is not running
+    if (prefillDesign && prefillContent && !isRunning && !prefillConsumedRef.current) {
+      prefillConsumedRef.current = true
+      onPrefillConsumed?.()
+    }
+  }, [prefillContent]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Reset the ref when prefill is cleared (parent reset regeneratingFrom)
+  useEffect(() => {
+    if (!prefillDesign && !prefillContent) {
+      prefillConsumedRef.current = false
+    }
+  }, [prefillDesign, prefillContent])
 
   const canSubmit =
     !isRunning &&


### PR DESCRIPTION
## Summary
- **Bug fix**: "My Sites" button was visible to anonymous users. Now gated behind `isSignedIn`.
- **Regenerate endpoint**: Changed from 501 stub to 200, returning stored site URLs. Also fixed API key decryption bug (was assigning ciphertext directly instead of decrypting).
- **UI**: "Regenerate" button added to My Sites panel (signed-in only). Pre-fills URL inputs in main page and auto-triggers a clone with the stored model.
- **UrlInputPanel**: Added `prefillDesign`/`prefillContent`/`onPrefillConsumed` props for URL pre-filling from site regeneration.

## Test plan
- [ ] "My Sites" button hidden when not signed in
- [ ] "Regenerate" button visible and works when signed in
- [ ] Regenerate auto-fills URLs and model and starts cloning
- [ ] All 233 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)