### PR TITLE
feat: UI/UX overhaul — hover states, animations, browser chrome preview

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,7 @@
   --color-bg-base: #07080d;
   --color-bg-primary: #0d0f18;
   --color-bg-elevated: #12141f;
+  --color-bg-surface: #161824;
   --color-bg-input: #0d0f18;
   --color-bg-hover: rgba(255,255,255,0.04);
 
@@ -27,6 +28,20 @@
   --color-success: #1d9e75;
   --color-warning: #D29922;
   --color-error: #F85149;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.2), 0 1px 3px rgba(0,0,0,0.1);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.25), 0 2px 4px rgba(0,0,0,0.15);
+  --shadow-lg: 0 8px 24px rgba(0,0,0,0.35), 0 4px 8px rgba(0,0,0,0.2);
+  --shadow-xl: 0 16px 48px rgba(0,0,0,0.4), 0 8px 16px rgba(0,0,0,0.25);
+  --shadow-glow: 0 0 20px rgba(249,115,22,0.15), 0 0 40px rgba(249,115,22,0.05);
+
+  /* Transitions */
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+  --duration-slow: 350ms;
 }
 
 @theme inline {
@@ -67,10 +82,56 @@ body::after {
   mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black 0%, transparent 70%);
 }
 
-/* Logo dot animation */
+/* ============================================================
+   Global focus ring
+   ============================================================ */
+*:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* ============================================================
+   Animations
+   ============================================================ */
 @keyframes logo-pulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.6; transform: scale(0.85); }
+}
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slide-in-right {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up var(--duration-base) var(--ease-out) both;
+}
+
+.animate-fade-in {
+  animation: fade-in var(--duration-base) var(--ease-out) both;
+}
+
+.animate-slide-in-right {
+  animation: slide-in-right var(--duration-slow) var(--ease-out) both;
+}
+
+.animate-scale-in {
+  animation: scale-in var(--duration-base) var(--ease-out) both;
 }
 
 .logo-dot {
@@ -83,7 +144,110 @@ body::after {
   flex-shrink: 0;
 }
 
-/* Clerk modal overrides */
+/* ============================================================
+   Button system
+   ============================================================ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
+  user-select: none;
+}
+
+.btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* Primary: orange filled */
+.btn-primary {
+  background-color: var(--color-accent);
+  color: #000;
+}
+.btn-primary:hover:not(:disabled) {
+  background-color: var(--color-accent-hover);
+  box-shadow: var(--shadow-glow);
+}
+
+/* Secondary: border outline */
+.btn-secondary {
+  background-color: transparent;
+  border: 1px solid var(--color-border-bright);
+  color: var(--color-text-secondary);
+}
+.btn-secondary:hover:not(:disabled) {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background-color: var(--color-accent-dim);
+}
+
+/* Ghost: no border, subtle bg on hover */
+.btn-ghost {
+  background-color: transparent;
+  color: var(--color-text-muted);
+}
+.btn-ghost:hover:not(:disabled) {
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-secondary);
+}
+
+/* Danger: red on hover */
+.btn-danger {
+  background-color: transparent;
+  color: var(--color-text-muted);
+}
+.btn-danger:hover:not(:disabled) {
+  background-color: rgba(248, 81, 73, 0.1);
+  color: var(--color-error);
+}
+
+/* ============================================================
+   Interactive card
+   ============================================================ */
+.card-interactive {
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out),
+    background-color var(--duration-fast) var(--ease-out);
+}
+.card-interactive:hover {
+  border-color: var(--color-border-bright);
+  box-shadow: var(--shadow-sm);
+  background-color: var(--color-bg-surface);
+}
+
+/* ============================================================
+   Input hover
+   ============================================================ */
+.input-field {
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background-color var(--duration-fast) var(--ease-out);
+}
+.input-field:hover:not(:focus) {
+  border-color: var(--color-border-bright);
+  background-color: var(--color-bg-elevated);
+}
+
+/* ============================================================
+   Clerk modal overrides
+   ============================================================ */
 .cl-providerIcon {
   filter: brightness(0) saturate(100%) invert(56%) sepia(84%) saturate(1400%) hue-rotate(345deg) brightness(103%);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -192,7 +192,7 @@ export default function Home() {
       pushEvent({ type: 'status', message: 'Scraping and preparing...' })
 
       const effectiveModel = modelOverride ?? model
-    const params = new URLSearchParams({ designUrl, contentUrl, model: effectiveModel })
+      const params = new URLSearchParams({ designUrl, contentUrl, model: effectiveModel })
       if (sessionId) params.set('sessionId', sessionId)
       const prepRes = await fetch(`/api/prepare?${params}`, {
         headers,
@@ -478,12 +478,7 @@ export default function Home() {
           {isSignedIn && (
             <button
               onClick={openMySites}
-              className="text-xs px-3 py-1.5 rounded-md border transition-colors"
-              style={{
-                color: 'var(--color-text-secondary)',
-                borderColor: 'var(--color-border-bright)',
-                backgroundColor: 'transparent',
-              }}
+              className="btn btn-secondary text-xs px-3 py-1.5"
             >
               My Sites
             </button>
@@ -491,8 +486,7 @@ export default function Home() {
           {isSignedIn && apiKey && (
             <button
               onClick={handleClearApiKey}
-              className="text-xs"
-              style={{ color: 'var(--color-text-muted)' }}
+              className="btn btn-ghost text-xs px-2 py-1"
             >
               Remove API key
             </button>
@@ -501,22 +495,7 @@ export default function Home() {
             <UserButton />
           ) : (
             <SignInButton mode="redirect">
-              <button
-                className="text-xs px-3 py-1.5 rounded-md border transition-colors"
-                style={{
-                  color: 'var(--color-text-secondary)',
-                  borderColor: 'var(--color-border-bright)',
-                  backgroundColor: 'transparent',
-                }}
-                onMouseEnter={e => {
-                  (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--color-accent)'
-                  ;(e.currentTarget as HTMLButtonElement).style.color = 'var(--color-accent)'
-                }}
-                onMouseLeave={e => {
-                  (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--color-border-bright)'
-                  ;(e.currentTarget as HTMLButtonElement).style.color = 'var(--color-text-secondary)'
-                }}
-              >
+              <button className="btn btn-secondary text-xs px-3 py-1.5">
                 Sign in / Sign up
               </button>
             </SignInButton>
@@ -603,8 +582,7 @@ export default function Home() {
             <button
               onClick={handleDownload}
               disabled={isDownloading}
-              className="px-4 py-2 rounded-md text-sm font-medium disabled:opacity-50"
-              style={{ backgroundColor: 'var(--color-accent)', color: '#000' }}
+              className="btn btn-primary px-4 py-2 text-sm font-medium"
             >
               {isDownloading ? 'Preparing ZIP…' : 'Download ZIP'}
             </button>
@@ -629,7 +607,7 @@ export default function Home() {
               {isRunning && (
                 <button
                   onClick={() => { abortRef.current?.abort(); setIsRunning(false) }}
-                  className="px-2 py-0.5 rounded text-xs font-medium"
+                  className="btn px-2 py-0.5 rounded text-xs font-medium"
                   style={{ backgroundColor: 'var(--color-error)', color: '#fff' }}
                 >
                   Stop
@@ -665,9 +643,9 @@ export default function Home() {
           className="fixed inset-0 z-50 flex justify-end"
           onClick={() => setShowMySites(false)}
         >
-          <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+          <div className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-fade-in" />
           <div
-            className="relative w-full max-w-md h-full overflow-y-auto border-l flex flex-col"
+            className="relative w-full max-w-md h-full overflow-y-auto border-l flex flex-col animate-slide-in-right"
             style={{ backgroundColor: 'var(--color-bg-elevated)', borderColor: 'var(--color-border)' }}
             onClick={(e) => e.stopPropagation()}
           >
@@ -678,8 +656,7 @@ export default function Home() {
               <h2 className="text-base font-semibold" style={{ color: 'var(--color-text-primary)' }}>My Sites</h2>
               <button
                 onClick={() => setShowMySites(false)}
-                className="text-xs px-2 py-1 rounded"
-                style={{ color: 'var(--color-text-muted)' }}
+                className="btn btn-ghost text-xs px-2 py-1"
               >
                 ✕
               </button>
@@ -699,7 +676,7 @@ export default function Home() {
                   {mySites.map((site) => (
                     <div
                       key={site.id}
-                      className="rounded-lg border p-4 flex flex-col gap-2"
+                      className="card-interactive rounded-lg border p-4 flex flex-col gap-2"
                       style={{ borderColor: 'var(--color-border)', backgroundColor: 'var(--color-bg-surface)' }}
                     >
                       <div className="flex items-start justify-between gap-2">
@@ -731,11 +708,7 @@ export default function Home() {
                       <div className="flex gap-2 mt-1">
                         <button
                           onClick={() => openSite(site as Site & { runs?: Run[] })}
-                          className="text-xs px-3 py-1 rounded border transition-colors"
-                          style={{
-                            borderColor: 'var(--color-border-bright)',
-                            color: 'var(--color-text-secondary)',
-                          }}
+                          className="btn btn-secondary text-xs px-3 py-1"
                         >
                           {expandedSiteId === site.id ? 'Hide' : 'Show'} runs
                         </button>
@@ -745,11 +718,7 @@ export default function Home() {
                               setRegeneratingFrom(site as Site & { runs?: Run[] })
                               setShowMySites(false)
                             }}
-                            className="text-xs px-3 py-1 rounded border transition-colors"
-                            style={{
-                              borderColor: 'var(--color-border-bright)',
-                              color: 'var(--color-text-secondary)',
-                            }}
+                            className="btn btn-secondary text-xs px-3 py-1"
                           >
                             Regenerate
                           </button>
@@ -759,8 +728,7 @@ export default function Home() {
                             const newName = window.prompt('Rename site:', site.name)
                             if (newName?.trim()) handleRenameSite(site.id, newName.trim())
                           }}
-                          className="text-xs px-3 py-1 rounded"
-                          style={{ color: 'var(--color-text-muted)' }}
+                          className="btn btn-ghost text-xs px-3 py-1"
                         >
                           Rename
                         </button>
@@ -768,8 +736,7 @@ export default function Home() {
                           onClick={() => {
                             if (window.confirm('Delete this site?')) handleDeleteSite(site.id)
                           }}
-                          className="text-xs px-3 py-1 rounded ml-auto"
-                          style={{ color: 'var(--color-error)' }}
+                          className="btn btn-danger text-xs px-3 py-1 ml-auto"
                         >
                           Delete
                         </button>

--- a/src/components/ApiKeyInput.tsx
+++ b/src/components/ApiKeyInput.tsx
@@ -25,13 +25,13 @@ export default function ApiKeyInput({ onSave, onClose }: ApiKeyInputProps) {
 
   return (
     <div
-      className="fixed inset-0 flex items-center justify-center z-50"
-      style={{ backgroundColor: 'rgba(0,0,0,0.7)' }}
+      className="fixed inset-0 flex items-center justify-center z-50 animate-fade-in"
+      style={{ backgroundColor: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(4px)' }}
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-lg border p-6 flex flex-col gap-4"
-        style={{ backgroundColor: 'var(--color-bg-elevated)', borderColor: 'var(--color-border)' }}
+        className="w-full max-w-md rounded-lg border p-6 flex flex-col gap-4 animate-scale-in"
+        style={{ backgroundColor: 'var(--color-bg-elevated)', borderColor: 'var(--color-border)', boxShadow: 'var(--shadow-xl)' }}
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className="text-base font-semibold" style={{ color: 'var(--color-text-primary)' }}>
@@ -51,7 +51,7 @@ export default function ApiKeyInput({ onSave, onClose }: ApiKeyInputProps) {
             value={key}
             onChange={(e) => { setKey(e.target.value); setError('') }}
             placeholder={`${KEY_PREFIX}...`}
-            className="rounded-md border px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2"
+            className="input-field rounded-md border px-3 py-2 text-sm font-mono focus:outline-none focus:border-[var(--color-accent)]"
             style={{
               backgroundColor: 'var(--color-bg-input)',
               borderColor: error ? 'var(--color-error)' : 'var(--color-border)',
@@ -68,15 +68,13 @@ export default function ApiKeyInput({ onSave, onClose }: ApiKeyInputProps) {
         <div className="flex gap-2 justify-end">
           <button
             onClick={onClose}
-            className="px-4 py-2 rounded-md text-sm border"
-            style={{ borderColor: 'var(--color-border)', color: 'var(--color-text-secondary)' }}
+            className="btn btn-secondary px-4 py-2 text-sm"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
-            className="px-4 py-2 rounded-md text-sm font-medium text-white"
-            style={{ backgroundColor: 'var(--color-accent)' }}
+            className="btn btn-primary px-4 py-2 text-sm font-medium"
           >
             Save key
           </button>

--- a/src/components/DemoBanner.tsx
+++ b/src/components/DemoBanner.tsx
@@ -41,7 +41,7 @@ export default function DemoBanner({ runsUsed, runLimit, hasApiKey, isSignedIn, 
           <span> </span>
           <button
             onClick={onOpenApiKeyInput}
-            className="underline cursor-pointer"
+            className="underline cursor-pointer transition-colors hover:brightness-125"
             style={{ color: 'var(--color-accent)' }}
           >
             Add your API key to continue →
@@ -57,7 +57,7 @@ export default function DemoBanner({ runsUsed, runLimit, hasApiKey, isSignedIn, 
         <span> </span>
         <button
           onClick={onOpenApiKeyInput}
-          className="underline cursor-pointer"
+          className="underline cursor-pointer transition-colors hover:brightness-125"
           style={{ color: 'var(--color-accent)' }}
         >
           {runsUsed >= (runLimit ?? 0) - 1 ? 'Add your API key →' : 'Add your own API key →'}
@@ -77,7 +77,7 @@ export default function DemoBanner({ runsUsed, runLimit, hasApiKey, isSignedIn, 
           <span> · </span>
           <button
             onClick={onOpenApiKeyInput}
-            className="underline cursor-pointer"
+            className="underline cursor-pointer transition-colors hover:brightness-125"
             style={{ color: 'var(--color-accent)' }}
           >
             Sign in / Sign up to continue →

--- a/src/components/PagePreview.tsx
+++ b/src/components/PagePreview.tsx
@@ -54,32 +54,84 @@ export default function PagePreview({ page, isLoading, mobilePreview }: PagePrev
   if (mobilePreview) {
     return (
       <div
-        className="flex flex-1 justify-center overflow-auto"
+        className="flex flex-1 justify-center overflow-auto py-6"
         style={{ backgroundColor: 'var(--color-bg-base)', minHeight: 0 }}
       >
-        <iframe
-          src={iframeSrc}
-          title={page.title}
-          sandbox="allow-scripts allow-same-origin"
+        <div
+          className="flex flex-col shrink-0 rounded-[2rem] overflow-hidden"
           style={{
-            width: 375,
-            flexShrink: 0,
-            border: 'none',
-            boxShadow: '0 0 0 1px rgba(255,255,255,0.08), 0 8px 32px rgba(0,0,0,0.4)',
-            alignSelf: 'stretch',
+            width: 390,
+            boxShadow: '0 0 0 1px rgba(255,255,255,0.08), 0 0 0 8px var(--color-bg-elevated), 0 0 0 9px var(--color-border), 0 16px 48px rgba(0,0,0,0.5)',
+            alignSelf: 'flex-start',
           }}
-        />
+        >
+          {/* Phone notch bar */}
+          <div
+            className="flex items-center justify-center py-2 shrink-0"
+            style={{ backgroundColor: 'var(--color-bg-elevated)' }}
+          >
+            <div
+              className="rounded-full"
+              style={{ width: 80, height: 6, backgroundColor: 'var(--color-border-bright)' }}
+            />
+          </div>
+          <iframe
+            src={iframeSrc}
+            title={page.title}
+            sandbox="allow-scripts allow-same-origin"
+            style={{
+              width: 390,
+              height: 720,
+              border: 'none',
+            }}
+          />
+          {/* Home indicator */}
+          <div
+            className="flex items-center justify-center py-2 shrink-0"
+            style={{ backgroundColor: 'var(--color-bg-elevated)' }}
+          >
+            <div
+              className="rounded-full"
+              style={{ width: 120, height: 4, backgroundColor: 'var(--color-border-bright)' }}
+            />
+          </div>
+        </div>
       </div>
     )
   }
 
   return (
-    <iframe
-      src={iframeSrc}
-      title={page.title}
-      sandbox="allow-scripts allow-same-origin"
-      className="w-full flex-1 border-0"
-      style={{ minHeight: 0 }}
-    />
+    <div className="flex flex-col flex-1 min-h-0" style={{ backgroundColor: 'var(--color-bg-base)' }}>
+      {/* Browser chrome */}
+      <div
+        className="flex items-center gap-2 px-4 py-2 shrink-0 border-b"
+        style={{ backgroundColor: 'var(--color-bg-elevated)', borderColor: 'var(--color-border)' }}
+      >
+        {/* Traffic lights */}
+        <div className="flex gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: '#ff5f57' }} />
+          <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: '#febc2e' }} />
+          <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: '#28c840' }} />
+        </div>
+        {/* Address bar */}
+        <div
+          className="flex-1 px-3 py-1 rounded-md text-xs truncate"
+          style={{
+            backgroundColor: 'var(--color-bg-input)',
+            color: 'var(--color-text-muted)',
+            border: '1px solid var(--color-border)',
+          }}
+        >
+          {page.title}
+        </div>
+      </div>
+      <iframe
+        src={iframeSrc}
+        title={page.title}
+        sandbox="allow-scripts allow-same-origin"
+        className="w-full flex-1 border-0"
+        style={{ minHeight: 0 }}
+      />
+    </div>
   )
 }

--- a/src/components/ProgressFeed.tsx
+++ b/src/components/ProgressFeed.tsx
@@ -72,7 +72,7 @@ export default function ProgressFeed({ events, isRunning }: ProgressFeedProps) {
           return (
             <div
               key={i}
-              className="flex items-center gap-2 py-1"
+              className="flex items-center gap-2 py-1 animate-fade-in-up"
               style={{ color: isLast && isRunning ? 'var(--color-text-primary)' : 'var(--color-text-muted)' }}
             >
               {isLast && isRunning
@@ -86,7 +86,7 @@ export default function ProgressFeed({ events, isRunning }: ProgressFeedProps) {
 
         if (event.type === 'page_complete') {
           return (
-            <div key={i} className="flex items-center gap-2 py-1" style={{ color: 'var(--color-text-primary)' }}>
+            <div key={i} className="flex items-center gap-2 py-1 animate-fade-in-up" style={{ color: 'var(--color-text-primary)' }}>
               <Checkmark color="text-[var(--color-success)]" />
               <span>{event.page.navLabel}</span>
             </div>
@@ -95,7 +95,7 @@ export default function ProgressFeed({ events, isRunning }: ProgressFeedProps) {
 
         if (event.type === 'error') {
           return (
-            <div key={i} className="flex items-start gap-2 py-1" style={{ color: 'var(--color-error)' }}>
+            <div key={i} className="flex items-start gap-2 py-1 animate-fade-in-up" style={{ color: 'var(--color-error)' }}>
               <span className="w-4 shrink-0 mt-0.5 text-center">✕</span>
               <span>{event.error}</span>
             </div>
@@ -104,7 +104,7 @@ export default function ProgressFeed({ events, isRunning }: ProgressFeedProps) {
 
         if (event.type === 'warning') {
           return (
-            <div key={i} className="flex items-start gap-2 py-1" style={{ color: 'var(--color-warning)' }}>
+            <div key={i} className="flex items-start gap-2 py-1 animate-fade-in-up" style={{ color: 'var(--color-warning)' }}>
               <span className="w-4 shrink-0 mt-0.5 text-center">!</span>
               <span>{event.message}</span>
             </div>
@@ -113,7 +113,7 @@ export default function ProgressFeed({ events, isRunning }: ProgressFeedProps) {
 
         if (event.type === 'done') {
           return (
-            <div key={i} className="flex items-center gap-2 py-1 font-bold" style={{ color: 'var(--color-success)' }}>
+            <div key={i} className="flex items-center gap-2 py-1 font-bold animate-fade-in-up" style={{ color: 'var(--color-success)' }}>
               <Checkmark color="text-[var(--color-success)]" />
               <span>All pages complete</span>
             </div>

--- a/src/components/UrlInputPanel.tsx
+++ b/src/components/UrlInputPanel.tsx
@@ -130,7 +130,7 @@ export default function UrlInputPanel({ onClone, isRunning, disabled, model, onM
             placeholder="https://stripe.com"
             value={designUrl}
             onChange={(e) => { setDesignUrl(e.target.value); setDesignError('') }}
-            className="px-3 py-2 rounded-md text-sm border focus:outline-none focus:border-[var(--color-accent)]"
+            className="input-field px-3 py-2 rounded-md text-sm border focus:outline-none focus:border-[var(--color-accent)]"
             style={{
               backgroundColor: 'var(--color-bg-input)',
               borderColor: designError ? 'var(--color-error)' : 'var(--color-border)',
@@ -159,7 +159,7 @@ export default function UrlInputPanel({ onClone, isRunning, disabled, model, onM
             placeholder="https://your-site.com"
             value={contentUrl}
             onChange={(e) => { setContentUrl(e.target.value); setContentError('') }}
-            className="px-3 py-2 rounded-md text-sm border focus:outline-none focus:border-[var(--color-accent)]"
+            className="input-field px-3 py-2 rounded-md text-sm border focus:outline-none focus:border-[var(--color-accent)]"
             style={{
               backgroundColor: 'var(--color-bg-input)',
               borderColor: contentError ? 'var(--color-error)' : 'var(--color-border)',
@@ -190,8 +190,8 @@ export default function UrlInputPanel({ onClone, isRunning, disabled, model, onM
             onClick={pickRandom}
             aria-label="Random example"
             title="Pick a random pairing"
-            className="flex items-center justify-center w-6 h-6 rounded border transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
-            style={{ borderColor: 'var(--color-border)', color: 'var(--color-text-muted)', backgroundColor: 'transparent' }}
+            className="btn btn-ghost flex items-center justify-center w-6 h-6 rounded border"
+            style={{ borderColor: 'var(--color-border)' }}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <polyline points="16 3 21 3 21 8" />
@@ -202,71 +202,68 @@ export default function UrlInputPanel({ onClone, isRunning, disabled, model, onM
           </button>
         </div>
         <div className="flex gap-2 flex-wrap">
-          {EXAMPLES.map((ex) => (
-            <button
-              key={ex.label}
-              type="button"
-              onClick={() => applyExample(ex.design, ex.content)}
-              className="px-3 py-1 rounded-full text-xs border transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-text-primary)]"
-              style={{
-                borderColor: 'var(--color-border)',
-                color: 'var(--color-text-secondary)',
-                backgroundColor: 'transparent',
-              }}
-            >
-              {ex.label}
-            </button>
-          ))}
+          {EXAMPLES.map((ex) => {
+            const isSelected = designUrl === ex.design && contentUrl === ex.content
+            return (
+              <button
+                key={ex.label}
+                type="button"
+                onClick={() => applyExample(ex.design, ex.content)}
+                className="btn px-3 py-1 rounded-full text-xs border"
+                style={{
+                  borderColor: isSelected ? 'var(--color-accent)' : 'var(--color-border)',
+                  color: isSelected ? 'var(--color-accent)' : 'var(--color-text-secondary)',
+                  backgroundColor: isSelected ? 'var(--color-accent-dim)' : 'transparent',
+                }}
+              >
+                {ex.label}
+              </button>
+            )
+          })}
         </div>
       </div>
 
       {/* Model selector + Clone button row */}
       <div className="flex gap-3 items-center">
-        <div className="flex items-center gap-2">
-          <select
-            value={model}
-            onChange={(e) => onModelChange(e.target.value)}
-            disabled={!hasApiKey || isRunning}
-            className="px-3 py-2.5 rounded-md text-sm border focus:outline-none focus:border-[var(--color-accent)] disabled:opacity-50 disabled:cursor-not-allowed"
-            style={{
-              backgroundColor: 'var(--color-bg-input)',
-              borderColor: 'var(--color-border)',
-              color: 'var(--color-text-primary)',
-            }}
-            aria-label="Model"
-          >
-            {hasApiKey
-              ? MODEL_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>{o.label}</option>
-                ))
-              : <option value="claude-haiku-4-5-20251001">Haiku (fast)</option>
-            }
-          </select>
-        </div>
+        <select
+          value={model}
+          onChange={(e) => onModelChange(e.target.value)}
+          disabled={!hasApiKey || isRunning}
+          className="input-field px-3 py-2.5 rounded-md text-sm border focus:outline-none focus:border-[var(--color-accent)] disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{
+            backgroundColor: 'var(--color-bg-input)',
+            borderColor: 'var(--color-border)',
+            color: 'var(--color-text-primary)',
+          }}
+          aria-label="Model"
+        >
+          {hasApiKey
+            ? MODEL_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))
+            : <option value="claude-haiku-4-5-20251001">Haiku (fast)</option>
+          }
+        </select>
 
-      <button
-        type="button"
-        onClick={handleSubmit}
-        disabled={!canSubmit}
-        className="flex-1 py-2.5 rounded-md text-sm font-semibold flex items-center justify-center gap-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-        style={{
-          backgroundColor: canSubmit ? 'var(--color-accent)' : 'var(--color-bg-elevated)',
-          color: canSubmit ? '#000' : 'var(--color-text-muted)',
-        }}
-      >
-        {isRunning && (
-          <svg
-            aria-label="running"
-            className="w-4 h-4 animate-spin"
-            viewBox="0 0 24 24"
-            fill="none"
-          >
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-          </svg>
-        )}
-        {isRunning ? 'Cloning…' : 'Clone'}
-      </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="btn btn-primary flex-1 py-2.5 text-sm font-semibold"
+        >
+          {isRunning && (
+            <svg
+              aria-label="running"
+              className="w-4 h-4 animate-spin"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+            </svg>
+          )}
+          {isRunning ? 'Cloning…' : 'Clone'}
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **Button system**: All buttons now use a unified CSS class system (`.btn-primary`, `.btn-secondary`, `.btn-ghost`, `.btn-danger`) with hover glow, active press feedback (`scale(0.97)`), and consistent transition timing. Replaced all inline JS `onMouseEnter`/`onMouseLeave` handlers in `page.tsx`.
- **Input hover states**: URL inputs and API key input now have smooth border/background transitions on hover and focus.
- **Entrance animations**: My Sites panel slides in from the right (`animate-slide-in-right`) with a fading backdrop. ProgressFeed events animate in one-by-one (`animate-fade-in-up`). ApiKeyInput modal scales in (`animate-scale-in`) with backdrop blur.
- **Browser chrome preview**: Desktop view now shows a macOS-style browser frame (traffic lights + address bar with page title). Mobile view gets a phone frame with notch and home indicator pill.
- **Interactive cards**: Site cards in My Sites panel lift slightly on hover (border brightens, shadow appears, bg shifts).
- **DemoBanner**: CTA links get brightness hover transition.

## Test plan

- [ ] All buttons show hover glow/accent color change on hover and slight press on click
- [ ] My Sites panel slides in from the right; backdrop fades in; clicking outside dismisses
- [ ] ProgressFeed events appear one at a time with a subtle fade-up animation
- [ ] Desktop preview shows browser chrome frame above iframe
- [ ] Mobile preview shows phone frame with notch/home bar
- [ ] ApiKeyInput modal scales in smoothly with blurred backdrop
- [x] `npm run lint` passes — 0 errors
- [x] `npm run test` passes — 230/230

🤖 Generated with [Claude Code](https://claude.com/claude-code)