### PR TITLE
feat: Stripe billing backend (M5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,19 @@ NEXT_PUBLIC_DEMO_RUN_LIMIT=3
 # existing encrypted user keys can no longer be decrypted — users must re-add them.
 API_KEY_KEK=your-64-char-hex-key-here
 
+# ─── Stripe ───────────────────────────────────────────────────────────────────
+# Secret key from https://dashboard.stripe.com → Developers → API keys
+STRIPE_SECRET_KEY=sk_test_...
+# Price ID for the Pro subscription (create in Stripe dashboard → Products)
+STRIPE_PRICE_ID=price_...
+# Webhook signing secret — from `stripe listen` locally, or Stripe dashboard
+# (Developers → Webhooks → your endpoint → Signing secret)
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# ─── App URL ─────────────────────────────────────────────────────────────────
+# Used to build success/cancel URLs in the checkout flow
+NEXT_PUBLIC_APP_URL=https://app.kaminify.com
+
 # ─── Sentry ───────────────────────────────────────────────────────────────────
 # DSN from https://sentry.io → project settings → Clients Keys
 SENTRY_DSN=https://...@o...ingest.sentry.io/...

--- a/src/app/api/checkout/__tests__/route.test.ts
+++ b/src/app/api/checkout/__tests__/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+  currentUser: vi.fn(),
+}))
+
+vi.mock('@/lib/stripe', () => ({
+  getOrCreateStripeCustomer: vi.fn(),
+  stripe: {
+    checkout: {
+      sessions: {
+        create: vi.fn(),
+      },
+    },
+  },
+  PRICE_ID: 'price_test_123',
+}))
+
+import { POST } from '../route'
+import { auth, currentUser } from '@clerk/nextjs/server'
+import { getOrCreateStripeCustomer, stripe } from '@/lib/stripe'
+
+const mockAuth = vi.mocked(auth)
+const mockCurrentUser = vi.mocked(currentUser)
+const mockGetOrCreateCustomer = vi.mocked(getOrCreateStripeCustomer)
+const mockSessionCreate = vi.mocked(stripe.checkout.sessions.create)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/checkout', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue({ userId: null } as never)
+
+    const res = await POST()
+    expect(res.status).toBe(401)
+  })
+
+  it('returns checkout session URL for authenticated user', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_abc' } as never)
+    mockCurrentUser.mockResolvedValue({
+      emailAddresses: [{ emailAddress: 'test@example.com' }],
+    } as never)
+    mockGetOrCreateCustomer.mockResolvedValue('cus_123')
+    mockSessionCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/cs_test' } as never)
+
+    const res = await POST()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.url).toBe('https://checkout.stripe.com/pay/cs_test')
+  })
+
+  it('creates Stripe customer and session with correct params', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user_abc' } as never)
+    mockCurrentUser.mockResolvedValue({
+      emailAddresses: [{ emailAddress: 'test@example.com' }],
+    } as never)
+    mockGetOrCreateCustomer.mockResolvedValue('cus_123')
+    mockSessionCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/cs_test' } as never)
+
+    await POST()
+
+    expect(mockGetOrCreateCustomer).toHaveBeenCalledWith('user_abc', 'test@example.com')
+    expect(mockSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: 'cus_123',
+        mode: 'subscription',
+        line_items: [{ price: 'price_test_123', quantity: 1 }],
+      }),
+    )
+  })
+})

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,0 +1,33 @@
+import { auth, currentUser } from '@clerk/nextjs/server'
+import { getOrCreateStripeCustomer, stripe, PRICE_ID } from '@/lib/stripe'
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.kaminify.com'
+
+export async function POST(): Promise<Response> {
+  const { userId } = await auth()
+
+  if (!userId) {
+    return new Response(JSON.stringify({ error: 'Not authenticated' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const user = await currentUser()
+  const email = user?.emailAddresses?.[0]?.emailAddress ?? ''
+
+  const customerId = await getOrCreateStripeCustomer(userId, email)
+
+  const session = await stripe.checkout.sessions.create({
+    customer: customerId,
+    mode: 'subscription',
+    line_items: [{ price: PRICE_ID, quantity: 1 }],
+    success_url: `${APP_URL}/?checkout=success`,
+    cancel_url: `${APP_URL}/`,
+  })
+
+  return new Response(JSON.stringify({ url: session.url }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/src/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type Stripe from 'stripe'
+
+vi.mock('@/lib/stripe', () => ({
+  stripe: {
+    webhooks: {
+      constructEvent: vi.fn(),
+    },
+  },
+  syncSubscriptionToDb: vi.fn(),
+}))
+
+import { POST } from '../route'
+import { stripe, syncSubscriptionToDb } from '@/lib/stripe'
+
+const mockConstructEvent = vi.mocked(stripe.webhooks.constructEvent)
+const mockSync = vi.mocked(syncSubscriptionToDb)
+
+function makeRequest(body = '{}', signature = 'valid-sig') {
+  return new Request('http://localhost/api/webhooks/stripe', {
+    method: 'POST',
+    body,
+    headers: { 'stripe-signature': signature },
+  })
+}
+
+function makeSubEvent(
+  type: string,
+  status: string,
+  customerId = 'cus_123',
+  subscriptionId = 'sub_456',
+): Stripe.Event {
+  return {
+    type,
+    data: {
+      object: {
+        id: subscriptionId,
+        status,
+        customer: customerId,
+      } as unknown as Stripe.Subscription,
+    },
+  } as unknown as Stripe.Event
+}
+
+function makeInvoiceEvent(customerId = 'cus_123'): Stripe.Event {
+  return {
+    type: 'invoice.payment_failed',
+    data: {
+      object: {
+        customer: customerId,
+      } as unknown as Stripe.Invoice,
+    },
+  } as unknown as Stripe.Event
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test'
+})
+
+// --- Signature verification ---------------------------------------------------
+
+describe('POST /api/webhooks/stripe — signature verification', () => {
+  it('returns 400 when signature verification fails', async () => {
+    mockConstructEvent.mockImplementation(() => {
+      throw new Error('No signatures found matching the expected signature')
+    })
+
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toContain('signature verification failed')
+  })
+})
+
+// --- customer.subscription.created ------------------------------------------
+
+describe('POST /api/webhooks/stripe — customer.subscription.created', () => {
+  it('calls syncSubscriptionToDb with pro when status is active', async () => {
+    const event = makeSubEvent('customer.subscription.created', 'active')
+    mockConstructEvent.mockReturnValue(event)
+
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(200)
+    expect(mockSync).toHaveBeenCalledWith('cus_123', 'pro', 'sub_456')
+  })
+
+  it('calls syncSubscriptionToDb with free when status is not active', async () => {
+    const event = makeSubEvent('customer.subscription.created', 'past_due')
+    mockConstructEvent.mockReturnValue(event)
+
+    await POST(makeRequest())
+    expect(mockSync).toHaveBeenCalledWith('cus_123', 'free', 'sub_456')
+  })
+})
+
+// --- customer.subscription.updated ------------------------------------------
+
+describe('POST /api/webhooks/stripe — customer.subscription.updated', () => {
+  it('upgrades to pro when subscription becomes active', async () => {
+    const event = makeSubEvent('customer.subscription.updated', 'active')
+    mockConstructEvent.mockReturnValue(event)
+
+    await POST(makeRequest())
+    expect(mockSync).toHaveBeenCalledWith('cus_123', 'pro', 'sub_456')
+  })
+
+  it('downgrades to free when subscription is cancelled', async () => {
+    const event = makeSubEvent('customer.subscription.updated', 'canceled')
+    mockConstructEvent.mockReturnValue(event)
+
+    await POST(makeRequest())
+    expect(mockSync).toHaveBeenCalledWith('cus_123', 'free', 'sub_456')
+  })
+})
+
+// --- customer.subscription.deleted ------------------------------------------
+
+describe('POST /api/webhooks/stripe — customer.subscription.deleted', () => {
+  it('calls syncSubscriptionToDb with free and null subscription ID', async () => {
+    const event = makeSubEvent('customer.subscription.deleted', 'canceled')
+    mockConstructEvent.mockReturnValue(event)
+
+    await POST(makeRequest())
+    expect(mockSync).toHaveBeenCalledWith('cus_123', 'free', null)
+  })
+})
+
+// --- invoice.payment_failed --------------------------------------------------
+
+describe('POST /api/webhooks/stripe — invoice.payment_failed', () => {
+  it('downgrades user to free on payment failure', async () => {
+    const event = makeInvoiceEvent('cus_789')
+    mockConstructEvent.mockReturnValue(event)
+
+    await POST(makeRequest())
+    expect(mockSync).toHaveBeenCalledWith('cus_789', 'free', null)
+  })
+})
+
+// --- Unknown event types -----------------------------------------------------
+
+describe('POST /api/webhooks/stripe — unknown event type', () => {
+  it('returns 200 without calling syncSubscriptionToDb', async () => {
+    const event = { type: 'payment_intent.succeeded', data: { object: {} } } as unknown as Stripe.Event
+    mockConstructEvent.mockReturnValue(event)
+
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(200)
+    expect(mockSync).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,65 @@
+import type Stripe from 'stripe'
+import { stripe, syncSubscriptionToDb } from '@/lib/stripe'
+
+function customerId(customer: string | Stripe.Customer | Stripe.DeletedCustomer | null): string | null {
+  if (!customer) return null
+  return typeof customer === 'string' ? customer : customer.id
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const rawBody = await request.text()
+  const signature = request.headers.get('stripe-signature') ?? ''
+
+  let event: Stripe.Event
+  try {
+    event = stripe.webhooks.constructEvent(
+      rawBody,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET!,
+    )
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    return new Response(
+      JSON.stringify({ error: `Webhook signature verification failed: ${message}` }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  try {
+    switch (event.type) {
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated': {
+        const sub = event.data.object as Stripe.Subscription
+        const status = sub.status === 'active' ? 'pro' : 'free'
+        const cid = customerId(sub.customer)
+        if (cid) await syncSubscriptionToDb(cid, status, sub.id)
+        break
+      }
+      case 'customer.subscription.deleted': {
+        const sub = event.data.object as Stripe.Subscription
+        const cid = customerId(sub.customer)
+        if (cid) await syncSubscriptionToDb(cid, 'free', null)
+        break
+      }
+      case 'invoice.payment_failed': {
+        const invoice = event.data.object as Stripe.Invoice
+        const cid = customerId(invoice.customer)
+        if (cid) await syncSubscriptionToDb(cid, 'free', null)
+        break
+      }
+      default:
+        break
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    return new Response(
+      JSON.stringify({ error: `Webhook handler error: ${message}` }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  return new Response(JSON.stringify({ received: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,7 +1,60 @@
 import Stripe from 'stripe'
+import { adminClient } from './supabase'
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2025-01-27.acacia' as Stripe.LatestApiVersion,
 })
 
 export const PRICE_ID = process.env.STRIPE_PRICE_ID!
+
+/**
+ * Look up the Stripe customer ID for a user, creating a new Stripe customer if
+ * one doesn't exist yet. Persists the customer ID back to the users table.
+ */
+export async function getOrCreateStripeCustomer(
+  clerkUserId: string,
+  email: string,
+): Promise<string> {
+  const db = adminClient()
+
+  const { data: user } = await db
+    .from('users')
+    .select('stripe_customer_id')
+    .eq('clerk_user_id', clerkUserId)
+    .single()
+
+  if (user?.stripe_customer_id) {
+    return user.stripe_customer_id
+  }
+
+  const customer = await stripe.customers.create({
+    email,
+    metadata: { clerkUserId },
+  })
+
+  await db
+    .from('users')
+    .update({ stripe_customer_id: customer.id })
+    .eq('clerk_user_id', clerkUserId)
+
+  return customer.id
+}
+
+/**
+ * Update the users table with the latest subscription state. Called from the
+ * Stripe webhook handler whenever a subscription event arrives. Looks up the
+ * user by their Stripe customer ID.
+ */
+export async function syncSubscriptionToDb(
+  stripeCustomerId: string,
+  status: 'free' | 'pro',
+  stripeSubscriptionId: string | null,
+): Promise<void> {
+  await adminClient()
+    .from('users')
+    .update({
+      subscription_status: status,
+      stripe_subscription_id: stripeSubscriptionId,
+    })
+    .eq('stripe_customer_id', stripeCustomerId)
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,8 +1,16 @@
 import Stripe from 'stripe'
 import { adminClient } from './supabase'
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2025-01-27.acacia' as Stripe.LatestApiVersion,
+let _stripe: Stripe | null = null
+export const stripe: Stripe = new Proxy({} as Stripe, {
+  get(_target, prop) {
+    if (!_stripe) {
+      _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+        apiVersion: '2025-01-27.acacia' as Stripe.LatestApiVersion,
+      })
+    }
+    return Reflect.get(_stripe, prop)
+  },
 })
 
 export const PRICE_ID = process.env.STRIPE_PRICE_ID!

--- a/supabase/migrations/004_billing.sql
+++ b/supabase/migrations/004_billing.sql
@@ -1,0 +1,13 @@
+-- 004_billing.sql
+-- Add Stripe billing columns to the users table.
+-- Uses IF NOT EXISTS so it's safe to run against a DB that already has these
+-- columns (e.g. production where they were added manually).
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_customer_id     TEXT UNIQUE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_subscription_id TEXT UNIQUE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS subscription_status    TEXT NOT NULL DEFAULT 'free';
+
+-- Index used by the webhook handler to look up users by Stripe customer ID
+CREATE INDEX IF NOT EXISTS users_stripe_customer_id_idx
+  ON users(stripe_customer_id)
+  WHERE stripe_customer_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- Installs `stripe@20.4.1` — resolves the pre-existing typecheck error from the stub
- Implements `getOrCreateStripeCustomer()` and `syncSubscriptionToDb()` helpers in `src/lib/stripe.ts`
- `POST /api/webhooks/stripe` — verifies Stripe webhook signature, handles `customer.subscription.created/updated/deleted` and `invoice.payment_failed`, syncs `subscription_status` to the `users` table
- `POST /api/checkout` — creates a Stripe Checkout session for authenticated users (backend only, not linked in UI)
- `supabase/migrations/004_billing.sql` — idempotent `ALTER TABLE IF NOT EXISTS` for Stripe columns on `users`
- Updates `.env.example` with `STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`, `NEXT_PUBLIC_APP_URL`

**No user-facing UI** — backend plumbing only. Pricing page, upgrade CTAs, and tier gating deferred until after beta.

## Test plan

- [x] 241 tests pass (`npm run test`)
- [x] Lint clean (`npm run lint`)
- [x] Typecheck clean (`npm run typecheck`)
- [x] Webhook: invalid signature → 400
- [x] Webhook: `subscription.created` with `active` status → `syncSubscriptionToDb('pro')`
- [x] Webhook: `subscription.deleted` → `syncSubscriptionToDb('free', null)`
- [x] Checkout: unauthenticated → 401
- [x] Checkout: authenticated → returns `{ url }` from Stripe

🤖 Generated with [Claude Code](https://claude.com/claude-code)