### PR TITLE
feat: Upstash Redis rate limiting on prepare + compose (M6 #H)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,13 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 # Used to build success/cancel URLs in the checkout flow
 NEXT_PUBLIC_APP_URL=https://app.kaminify.com
 
+# ─── Upstash Redis (rate limiting) ───────────────────────────────────────────
+# Create a free Redis database at https://console.upstash.com
+# Used for sliding-window rate limiting on /api/prepare and /api/compose.
+# If unset, rate limiting is disabled (safe for dev/preview).
+UPSTASH_REDIS_REST_URL=https://...upstash.io
+UPSTASH_REDIS_REST_TOKEN=...
+
 # ─── Sentry ───────────────────────────────────────────────────────────────────
 # DSN from https://sentry.io → project settings → Clients Keys
 SENTRY_DSN=https://...@o...ingest.sentry.io/...

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@sentry/nextjs": "^10.45.0",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.37.0",
         "archiver": "^7.0.1",
         "cheerio": "^1.2.0",
         "next": "15.5.14",
@@ -4868,6 +4870,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -11706,6 +11741,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.24.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@sentry/nextjs": "^10.45.0",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "archiver": "^7.0.1",
     "cheerio": "^1.2.0",
     "next": "15.5.14",

--- a/src/app/api/compose/__tests__/route.test.ts
+++ b/src/app/api/compose/__tests__/route.test.ts
@@ -3,12 +3,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('@/lib/composer', () => ({
   composePage: vi.fn(),
 }))
+vi.mock('@/lib/rateLimit', () => ({
+  checkRateLimit: vi.fn(),
+  getRateLimitId: vi.fn(),
+}))
 
 import { POST } from '../route'
 import { composePage } from '@/lib/composer'
+import { checkRateLimit, getRateLimitId } from '@/lib/rateLimit'
 import type { ScrapedSite, DiscoveredPage, DesignSystem, PageContent } from '@/lib/types'
 
 const mockComposePage = vi.mocked(composePage)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+const mockGetRateLimitId = vi.mocked(getRateLimitId)
 
 const fakeSite: ScrapedSite = { url: 'https://example.com', html: '<html/>', css: '', title: 'Test', jsRendered: false }
 void fakeSite // used as reference fixture only
@@ -55,6 +62,8 @@ function parseEvents(raw: string) {
 beforeEach(() => {
   vi.clearAllMocks()
   delete process.env.ANTHROPIC_API_KEY
+  mockCheckRateLimit.mockResolvedValue({ limited: false, retryAfter: 0 })
+  mockGetRateLimitId.mockReturnValue('ip:127.0.0.1')
 })
 
 describe('POST /api/compose', () => {
@@ -230,5 +239,26 @@ describe('POST /api/compose', () => {
     expect(mockComposePage).toHaveBeenCalledWith(
       expect.anything(), expect.anything(), expect.anything(), expect.any(String), 'claude-sonnet-4-6', screenshots
     )
+  })
+
+  it('returns 429 when rate limiter rejects the request', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockCheckRateLimit.mockResolvedValue({ limited: true, retryAfter: 45 })
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages }))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.error).toMatch(/Too many requests/)
+    expect(res.headers.get('Retry-After')).toBe('45')
+  })
+
+  it('passes through when rate limiter allows the request', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockCheckRateLimit.mockResolvedValue({ limited: false, retryAfter: 0 })
+    mockComposePage.mockResolvedValue(fakeHtml)
+
+    const res = await POST(makeRequest({ designSystem: fakeDesign, pageContent: fakeContent, allPages: fakePages }))
+    expect(res.status).toBe(200)
+    await collectStream(res)
   })
 })

--- a/src/app/api/compose/route.ts
+++ b/src/app/api/compose/route.ts
@@ -4,6 +4,7 @@ import { adminClient } from '@/lib/supabase'
 import { deserialiseEncryptedKey, decryptApiKey } from '@/lib/api-key-crypto'
 import { logComposePage, logRunError } from '@/lib/site-storage'
 import type { CloneEvent, ClonedPage, DesignSystem, DiscoveredPage, PageContent } from '@/lib/types'
+import { checkRateLimit, getRateLimitId } from '@/lib/rateLimit'
 
 const encoder = new TextEncoder()
 
@@ -71,6 +72,14 @@ export async function POST(request: Request): Promise<Response> {
 
   if (!effectiveApiKey) {
     return new Response('Unauthorized', { status: 401 })
+  }
+
+  const { limited, retryAfter } = await checkRateLimit(getRateLimitId(request, signedInUserId))
+  if (limited) {
+    return new Response(JSON.stringify({ error: 'Too many requests' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) },
+    })
   }
 
   let body: ComposeBody

--- a/src/app/api/prepare/__tests__/route.test.ts
+++ b/src/app/api/prepare/__tests__/route.test.ts
@@ -13,12 +13,17 @@ vi.mock('@/lib/extractor', () => ({
   extractDesignSystem: vi.fn(),
   extractPageContent: vi.fn(),
 }))
+vi.mock('@/lib/rateLimit', () => ({
+  checkRateLimit: vi.fn(),
+  getRateLimitId: vi.fn(),
+}))
 
 import { GET } from '../route'
 import { scrapeSite } from '@/lib/scraper'
 import { scrapeWithBrowser } from '@/lib/browserScraper'
 import { discoverPages } from '@/lib/discover'
 import { extractDesignSystem, extractPageContent } from '@/lib/extractor'
+import { checkRateLimit, getRateLimitId } from '@/lib/rateLimit'
 import type { ScrapedSite, DiscoveredPage, DesignSystem, PageContent } from '@/lib/types'
 
 const mockScrapeSite = vi.mocked(scrapeSite)
@@ -26,6 +31,8 @@ const mockScrapeWithBrowser = vi.mocked(scrapeWithBrowser)
 const mockDiscoverPages = vi.mocked(discoverPages)
 const mockExtractDesignSystem = vi.mocked(extractDesignSystem)
 const mockExtractPageContent = vi.mocked(extractPageContent)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+const mockGetRateLimitId = vi.mocked(getRateLimitId)
 
 const fakeSite: ScrapedSite = { url: 'https://example.com', html: '<html/>', css: '', title: 'Test', jsRendered: false }
 const fakePages: DiscoveredPage[] = [
@@ -51,6 +58,8 @@ function makeRequest(params: Record<string, string>, headers: Record<string, str
 beforeEach(() => {
   vi.clearAllMocks()
   delete process.env.ANTHROPIC_API_KEY
+  mockCheckRateLimit.mockResolvedValue({ limited: false, retryAfter: 0 })
+  mockGetRateLimitId.mockReturnValue('ip:127.0.0.1')
 })
 
 describe('GET /api/prepare', () => {
@@ -200,5 +209,28 @@ describe('GET /api/prepare', () => {
 
     const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
     expect(res.status).toBe(500)
+  })
+
+  it('returns 429 when rate limiter rejects the request', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockCheckRateLimit.mockResolvedValue({ limited: true, retryAfter: 30 })
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.error).toMatch(/Too many requests/)
+    expect(res.headers.get('Retry-After')).toBe('30')
+  })
+
+  it('passes through when rate limiter allows the request', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+    mockCheckRateLimit.mockResolvedValue({ limited: false, retryAfter: 0 })
+    mockScrapeSite.mockResolvedValue(fakeSite)
+    mockDiscoverPages.mockReturnValue(fakePages)
+    mockExtractDesignSystem.mockReturnValue(fakeDesign)
+    mockExtractPageContent.mockReturnValue(fakeContent)
+
+    const res = await GET(makeRequest({ designUrl: 'https://stripe.com', contentUrl: 'https://example.com' }))
+    expect(res.status).toBe(200)
   })
 })

--- a/src/app/api/prepare/route.ts
+++ b/src/app/api/prepare/route.ts
@@ -8,6 +8,7 @@ import { adminClient } from '@/lib/supabase'
 import { logPrepareRun } from '@/lib/site-storage'
 import { deserialiseEncryptedKey, decryptApiKey } from '@/lib/api-key-crypto'
 import type { DesignSystem, DiscoveredPage, PageContent } from '@/lib/types'
+import { checkRateLimit, getRateLimitId } from '@/lib/rateLimit'
 
 const BYOK_MODELS = ['claude-haiku-4-5-20251001', 'claude-sonnet-4-6', 'claude-opus-4-6']
 
@@ -112,6 +113,14 @@ export async function GET(request: Request): Promise<Response> {
     return new Response(JSON.stringify({ error: 'No API key available' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const { limited, retryAfter } = await checkRateLimit(getRateLimitId(request, signedInUserId))
+  if (limited) {
+    return new Response(JSON.stringify({ error: 'Too many requests' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) },
     })
   }
 

--- a/src/lib/__tests__/rateLimit.test.ts
+++ b/src/lib/__tests__/rateLimit.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockLimit = vi.fn()
+
+vi.mock('@upstash/ratelimit', () => ({
+  Ratelimit: Object.assign(
+    vi.fn().mockImplementation(function () {
+      return { limit: mockLimit }
+    }),
+    {
+      slidingWindow: vi.fn().mockReturnValue('sliding-window-config'),
+    },
+  ),
+}))
+
+vi.mock('@upstash/redis', () => ({
+  Redis: vi.fn().mockImplementation(function () {
+    return {}
+  }),
+}))
+
+import { checkRateLimit, getRateLimitId } from '../rateLimit'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.resetModules()
+})
+
+describe('checkRateLimit', () => {
+  it('returns { limited: false } when Upstash env vars are not set', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL
+    delete process.env.UPSTASH_REDIS_REST_TOKEN
+
+    const result = await checkRateLimit('user:test')
+    expect(result).toEqual({ limited: false, retryAfter: 0 })
+  })
+
+  it('returns { limited: false } when limiter allows the request', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://test.upstash.io'
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
+    mockLimit.mockResolvedValue({ success: true, reset: Date.now() + 60000 })
+
+    const { checkRateLimit: freshCheck } = await import('../rateLimit')
+    const result = await freshCheck('user:abc')
+    expect(result.limited).toBe(false)
+  })
+
+  it('returns { limited: true } with retryAfter when limiter rejects', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://test.upstash.io'
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
+    const future = Date.now() + 30000
+    mockLimit.mockResolvedValue({ success: false, reset: future })
+
+    const { checkRateLimit: freshCheck } = await import('../rateLimit')
+    const result = await freshCheck('user:abc')
+    expect(result.limited).toBe(true)
+    expect(result.retryAfter).toBeGreaterThan(0)
+  })
+})
+
+describe('getRateLimitId', () => {
+  it('returns user:<id> for authenticated users', () => {
+    const req = new Request('http://localhost/api/prepare')
+    expect(getRateLimitId(req, 'user_abc')).toBe('user:user_abc')
+  })
+
+  it('returns ip:<ip> from x-forwarded-for for anonymous users', () => {
+    const req = new Request('http://localhost/api/prepare', {
+      headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
+    })
+    expect(getRateLimitId(req, null)).toBe('ip:1.2.3.4')
+  })
+
+  it('returns ip:<ip> from x-real-ip when x-forwarded-for is absent', () => {
+    const req = new Request('http://localhost/api/prepare', {
+      headers: { 'x-real-ip': '9.10.11.12' },
+    })
+    expect(getRateLimitId(req, null)).toBe('ip:9.10.11.12')
+  })
+
+  it('returns ip:unknown when no IP headers are present', () => {
+    const req = new Request('http://localhost/api/prepare')
+    expect(getRateLimitId(req, null)).toBe('ip:unknown')
+  })
+})

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,48 @@
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+
+let _limiter: Ratelimit | null | undefined = undefined
+
+function getLimiter(): Ratelimit | null {
+  if (_limiter !== undefined) return _limiter
+  const url = process.env.UPSTASH_REDIS_REST_URL
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN
+  if (!url || !token) {
+    _limiter = null
+    return null
+  }
+  _limiter = new Ratelimit({
+    redis: new Redis({ url, token }),
+    limiter: Ratelimit.slidingWindow(10, '1 m'),
+    prefix: 'kaminify:rl',
+  })
+  return _limiter
+}
+
+/**
+ * Check rate limit for a given identifier. Returns { limited: false } when
+ * Upstash is not configured (graceful degradation for dev/preview).
+ */
+export async function checkRateLimit(
+  identifier: string,
+): Promise<{ limited: boolean; retryAfter: number }> {
+  const limiter = getLimiter()
+  if (!limiter) return { limited: false, retryAfter: 0 }
+
+  const { success, reset } = await limiter.limit(identifier)
+  const retryAfter = success ? 0 : Math.ceil((reset - Date.now()) / 1000)
+  return { limited: !success, retryAfter }
+}
+
+/**
+ * Build the rate limit identifier from the request context.
+ * Authenticated users are keyed by Clerk user ID; anonymous by IP address.
+ */
+export function getRateLimitId(request: Request, userId: string | null): string {
+  if (userId) return `user:${userId}`
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+    request.headers.get('x-real-ip') ??
+    'unknown'
+  return `ip:${ip}`
+}


### PR DESCRIPTION
## Summary

- Adds sliding-window rate limiting (10 req/min) to `/api/prepare` and `/api/compose`
- Authenticated users keyed by Clerk user ID; anonymous users keyed by IP (`x-forwarded-for` → `x-real-ip` → `unknown`)
- Graceful no-op when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are unset — builds and preview deploys are unaffected
- Returns `429` with `Retry-After` header when limit is exceeded

## New env vars (optional — rate limiting disabled if absent)

```
UPSTASH_REDIS_REST_URL=https://...upstash.io
UPSTASH_REDIS_REST_TOKEN=...
```

## Test plan

- [ ] 252 tests passing (`npm run test`)
- [ ] Lint clean (`npm run lint`)
- [ ] With env vars unset: routes work normally (no rate limiting applied)
- [ ] With env vars set: 11th request within a minute returns 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)